### PR TITLE
Make cmake project modular

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -3,7 +3,7 @@
 function install() {
 	wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-shared-with-deps-latest.zip
 	unzip libtorch-shared-with-deps-latest.zip
-  rm -rf libtorch-shared-with-deps-latest.zip
+	rm -rf libtorch-shared-with-deps-latest.zip
 }
 
 function build() {
@@ -15,11 +15,13 @@ function build() {
 }
 
 function lint() {
-	cpplint --linelength=120 main.cpp tutorials/*/*/**
+	cpplint --linelength=120 --recursive \
+		--filter=-build/include_subdir,-build/include_what_you_use main.cpp tutorials/*/*/**
 }
 
 function lintci() {
-	python cpplint.py --linelength=120 main.cpp tutorials/*/*/**
+	python cpplint.py --linelength=120 --recursive \
+		--filter=-build/include_subdir,-build/include_what_you_use main.cpp tutorials/*/*/**
 }
 
 if [ $1 = "install" ]

--- a/tutorials/basics/feedforward_neural_network/CMakeLists.txt
+++ b/tutorials/basics/feedforward_neural_network/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(pytorch-cpp VERSION 1.0.0 LANGUAGES CXX)
+project(feedforward-neural-network VERSION 1.0.0 LANGUAGES CXX)
 
-find_package(Torch REQUIRED)
+#find_package(Torch REQUIRED)
 
-set(EXECUTABLE_NAME pytorch-cpp)
-add_executable(${EXECUTABLE_NAME} main.cpp)
+set(SOURCES main.cpp)
+
+set(EXECUTABLE_NAME feedforward-neural-network)
+
+add_executable(${EXECUTABLE_NAME} ${SOURCES})
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
 )
-
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
-
-# Add tutorial projects:
-add_subdirectory("tutorials/basics/feedforward_neural_network")
-add_subdirectory("tutorials/basics/linear_regression")
-add_subdirectory("tutorials/basics/logistic_regression")
-add_subdirectory("tutorials/basics/pytorch_basics")
 
 # The following code block is suggested to be used on Windows.
 # According to https://github.com/pytorch/pytorch/issues/25457,

--- a/tutorials/basics/linear_regression/CMakeLists.txt
+++ b/tutorials/basics/linear_regression/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(pytorch-cpp VERSION 1.0.0 LANGUAGES CXX)
+project(linear-regression VERSION 1.0.0 LANGUAGES CXX)
 
-find_package(Torch REQUIRED)
+#find_package(Torch REQUIRED)
 
-set(EXECUTABLE_NAME pytorch-cpp)
-add_executable(${EXECUTABLE_NAME} main.cpp)
+set(SOURCES main.cpp)
+
+set(EXECUTABLE_NAME linear-regression)
+
+add_executable(${EXECUTABLE_NAME} ${SOURCES})
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
 )
-
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
-
-# Add tutorial projects:
-add_subdirectory("tutorials/basics/feedforward_neural_network")
-add_subdirectory("tutorials/basics/linear_regression")
-add_subdirectory("tutorials/basics/logistic_regression")
-add_subdirectory("tutorials/basics/pytorch_basics")
 
 # The following code block is suggested to be used on Windows.
 # According to https://github.com/pytorch/pytorch/issues/25457,

--- a/tutorials/basics/logistic_regression/CMakeLists.txt
+++ b/tutorials/basics/logistic_regression/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(pytorch-cpp VERSION 1.0.0 LANGUAGES CXX)
+project(logistic-regression VERSION 1.0.0 LANGUAGES CXX)
 
-find_package(Torch REQUIRED)
+#find_package(Torch REQUIRED)
 
-set(EXECUTABLE_NAME pytorch-cpp)
-add_executable(${EXECUTABLE_NAME} main.cpp)
+set(SOURCES main.cpp)
+
+set(EXECUTABLE_NAME logistic-regression)
+
+add_executable(${EXECUTABLE_NAME} ${SOURCES})
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
 )
-
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
-
-# Add tutorial projects:
-add_subdirectory("tutorials/basics/feedforward_neural_network")
-add_subdirectory("tutorials/basics/linear_regression")
-add_subdirectory("tutorials/basics/logistic_regression")
-add_subdirectory("tutorials/basics/pytorch_basics")
 
 # The following code block is suggested to be used on Windows.
 # According to https://github.com/pytorch/pytorch/issues/25457,

--- a/tutorials/basics/pytorch_basics/CMakeLists.txt
+++ b/tutorials/basics/pytorch_basics/CMakeLists.txt
@@ -1,23 +1,20 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-project(pytorch-cpp VERSION 1.0.0 LANGUAGES CXX)
+project(pytorch-basics VERSION 1.0.0 LANGUAGES CXX)
 
-find_package(Torch REQUIRED)
+#find_package(Torch REQUIRED)
 
-set(EXECUTABLE_NAME pytorch-cpp)
-add_executable(${EXECUTABLE_NAME} main.cpp)
+set(SOURCES main.cpp)
+
+set(EXECUTABLE_NAME pytorch-basics)
+
+add_executable(${EXECUTABLE_NAME} ${SOURCES})
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
 )
-
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
-
-# Add tutorial projects:
-add_subdirectory("tutorials/basics/feedforward_neural_network")
-add_subdirectory("tutorials/basics/linear_regression")
-add_subdirectory("tutorials/basics/logistic_regression")
-add_subdirectory("tutorials/basics/pytorch_basics")
 
 # The following code block is suggested to be used on Windows.
 # According to https://github.com/pytorch/pytorch/issues/25457,


### PR DESCRIPTION
**Description**
This adds each tutorial as a sub-cmake-project. I think that this makes it easier to add the other tutorials. I have already worked (locally) on the "Convolutional Neural Networks" and the Deep Residual Network" tutorials where I am using several source/header files and being able to use subproject-specific CMakeLists.txt-files is very handy. I could open follow-up pull requests to add those two tutorial subprojects.