### PR TITLE
Add function to download datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 ## Getting Started
 - Fork/Clone and Install
-```
+```bash
 $ git clone https://github.com/prabhuomkar/pytorch-cpp.git
 $ chmod +x scripts.sh
-$ ./scripts.sh install
+$ ./scripts.sh install #optional: --cuda=(9.2 or 10.1) to install libtorch cuda versions (by default cpu version is installed) 
+```
+- Download all datasets used in the tutorials
+```bash
+$ ./scripts.sh download_datasets
 ```
 - Build
-```
+```bash
 $ ./scripts.sh build
 ```
 

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,41 +1,152 @@
 #!/bin/bash
 
 function install() {
-	wget https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.3.1%2Bcpu.zip
-	unzip libtorch-shared-with-deps-1.3.1+cpu.zip
-	rm -rf libtorch-shared-with-deps-1.3.1+cpu.zip
+    PYTORCH_VERSION="1.3.1"
+
+    case $1 in
+        --cuda=*)
+            cuda="${1#*=}"
+            ;;
+        *)
+    esac
+    
+    cuda="${cuda:-None}"
+    
+    case $cuda in
+        9.2|10.1|None)
+        ;;
+        *)
+        echo "Invalid cuda version, expected \"9.2\", \"10.1\" or \"None\"(cpu) but got: \"${cuda}\""
+        return -1
+        ;;
+    esac
+    
+    if [ $cuda = "None" ]; then
+        echo "Downloading libtorch for cpu, build-version ${PYTORCH_VERSION}..."
+        wget "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-${PYTORCH_VERSION}%2Bcpu.zip"
+        unzip "libtorch-shared-with-deps-${PYTORCH_VERSION}+cpu.zip"
+        rm -rf "libtorch-shared-with-deps-${PYTORCH_VERSION}+cpu.zip"
+    elif [ $cuda = "10.1" ]; then
+        echo "Downloading libtorch for gpu (CUDA ${cuda}), build-version ${PYTORCH_VERSION}..."
+        wget "https://download.pytorch.org/libtorch/cu101/libtorch-shared-with-deps-${PYTORCH_VERSION}.zip"
+        unzip "libtorch-shared-with-deps-${PYTORCH_VERSION}.zip"
+        rm -rf "libtorch-shared-with-deps-${PYTORCH_VERSION}.zip"
+    elif [ $cuda = "9.2" ]; then
+        echo "Downloading libtorch for gpu (CUDA ${cuda}), build-version ${PYTORCH_VERSION}..."
+        wget "https://download.pytorch.org/libtorch/cu92/libtorch-shared-with-deps-${PYTORCH_VERSION}%2Bcu92.zip"
+        unzip "libtorch-shared-with-deps-${PYTORCH_VERSION}+cu92.zip"
+        rm -rf "libtorch-shared-with-deps-${PYTORCH_VERSION}+cu92.zip"
+    fi      
 }
 
 function build() {
-	rm -rf build
-	mkdir build
-	cd build
-	cmake -DCMAKE_PREFIX_PATH=$(dirname $(pwd))/libtorch ..
-	make
+    rm -rf build
+    mkdir build
+    cd build
+    cmake -DCMAKE_PREFIX_PATH=$(dirname $(pwd))/libtorch ..
+    make
 }
 
 function lint() {
-	cpplint --linelength=120 --recursive \
-		--filter=-build/include_subdir,-build/include_what_you_use \
-		--exclude=tutorials/advanced/utils/include/external/* main.cpp tutorials/*/*/**
+    cpplint --linelength=120 --recursive \
+        --filter=-build/include_subdir,-build/include_what_you_use \
+        --exclude=tutorials/advanced/utils/include/external/* main.cpp tutorials/*/*/**
 }
 
 function lintci() {
-	python cpplint.py --linelength=120 --recursive \
-		--filter=-build/include_subdir,-build/include_what_you_use \
-		--exclude=tutorials/advanced/utils/include/external/* main.cpp tutorials/*/*/**
+    python cpplint.py --linelength=120 --recursive \
+        --filter=-build/include_subdir,-build/include_what_you_use \
+        --exclude=tutorials/advanced/utils/include/external/* main.cpp tutorials/*/*/**
+}
+
+function download_mnist() {
+    echo "---MNIST---"
+    mnist_dir="data/mnist"
+    mnist_base_url="http://yann.lecun.com/exdb/mnist"
+    mkdir -p $mnist_dir
+    
+    declare -a files
+    files=( "train-images-idx3-ubyte" "train-labels-idx1-ubyte" \
+    "t10k-images-idx3-ubyte" "t10k-labels-idx1-ubyte" )
+    
+    for file in "${files[@]}"
+    do
+        if [ -f "${mnist_dir}/${file}" ]; then
+            echo "${mnist_dir}/${file} already exists, skipping..."
+        else
+            wget "${mnist_base_url}/${file}.gz" -P $mnist_dir 
+            gunzip "${mnist_dir}/${file}.gz"
+        fi
+    done
+}
+
+function download_cifar10() {
+    echo "---CIFAR10---"
+    cifar_dir="data/cifar10"
+    cifar_url="https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz"
+    mkdir -p $cifar_dir
+    
+    declare -a files
+    files=( "data_batch_1.bin" "data_batch_2.bin" "data_batch_3.bin" \
+    "data_batch_4.bin" "data_batch_5.bin" "test_batch.bin" )
+    
+    files_already_exist=true
+    
+    for file in "${files[@]}"
+    do
+        if [ ! -f "${cifar_dir}/${file}" ]; then
+            files_already_exist=false
+            break
+        fi
+    done
+    
+    if [ "$files_already_exist" = true ]; then
+        echo "Files already exist, skipping..."
+    else
+        wget $cifar_url -P $cifar_dir
+        tar xf "${cifar_dir}/cifar-10-binary.tar.gz" -C $cifar_dir
+        rm "${cifar_dir}/cifar-10-binary.tar.gz"
+        mv "${cifar_dir}/cifar-10-batches-bin/"* "${cifar_dir}"
+        rm -rf "${cifar_dir}/cifar-10-batches-bin"
+    fi
+}
+
+function download_penntreebank() {
+    echo "---Penn Treebank---"
+    penntreebank_dir="data/penntreebank"
+    mkdir -p $penntreebank_dir
+    penntreebank_url="https://raw.githubusercontent.com/wojzaremba/lstm/master/data/ptb.train.txt"
+    
+    train_filename="train.txt"
+    
+    if [ -f "${penntreebank_dir}/${train_filename}" ]; then
+        echo "${penntreebank_dir}/${train_filename} already exists, skipping..."
+    else
+        wget $penntreebank_url -O "${penntreebank_dir}/${train_filename}"
+    fi
+}
+
+function download_datasets() {
+    download_mnist
+    echo
+    download_cifar10
+    echo
+    download_penntreebank
 }
 
 if [ $1 = "install" ]
 then
-	install
+    install $2
 elif [ $1 = "build" ]
 then
-	build
+    build
 elif [ $1 = "lint" ]
 then
-	lint
+    lint
 elif [ $1 = "lintci" ]
 then
-	lintci
+    lintci
+elif [ $1 = "download_datasets" ]
+then
+    download_datasets
 fi

--- a/tutorials/advanced/generative_adversarial_network/main.cpp
+++ b/tutorials/advanced/generative_adversarial_network/main.cpp
@@ -20,9 +20,9 @@ int main() {
     const int64_t batch_size = 100;
     const double learning_rate = 0.0002;
 
-    const std::string MNIST_data_path = "../../../../tutorials/advanced/generative_adversarial_network/data/";
+    const std::string MNIST_data_path = "../../../../data/mnist/";
 
-    // Path were the generates samples will be saved to
+    // Path of the directory where the generated samples will be saved to
     const std::string sample_path = "../../../../tutorials/advanced/generative_adversarial_network/samples/";
 
     // MNIST dataset

--- a/tutorials/basics/feedforward_neural_network/main.cpp
+++ b/tutorials/basics/feedforward_neural_network/main.cpp
@@ -41,11 +41,13 @@ int main() {
   }
   torch::Device device(device_type);
 
+  const std::string MNIST_data_path = "../../../../data/mnist/";
+
   // MNIST Dataset (images and labels)
-  auto train_dataset = torch::data::datasets::MNIST("../data")
+  auto train_dataset = torch::data::datasets::MNIST(MNIST_data_path)
                            .map(torch::data::transforms::Normalize<>(0.1307, 0.3081))
                            .map(torch::data::transforms::Stack<>());
-  auto test_dataset = torch::data::datasets::MNIST("../data", torch::data::datasets::MNIST::Mode::kTest)
+  auto test_dataset = torch::data::datasets::MNIST(MNIST_data_path, torch::data::datasets::MNIST::Mode::kTest)
                            .map(torch::data::transforms::Normalize<>(0.1307, 0.3081))
                            .map(torch::data::transforms::Stack<>());
 
@@ -57,6 +59,7 @@ int main() {
 
   // Neural Network model
   auto model = std::make_shared<NeuralNet>();
+  model->to(device);
 
   // Loss and optimizer
   auto optimizer = torch::optim::SGD(model->parameters(), torch::optim::SGDOptions(learning_rate));
@@ -65,7 +68,8 @@ int main() {
   for (int epoch = 0; epoch < num_epochs; epoch++) {
     int i = 0;
     for (auto& batch : *train_loader) {
-      auto data = batch.data.to(device), labels = batch.target.to(device);
+      auto data = batch.data.reshape({batch_size, -1}).to(device);
+      auto labels = batch.target.to(device);
 
       // Forward pass
       auto outputs = model->forward(data);
@@ -76,23 +80,27 @@ int main() {
       loss.backward();
       optimizer.step();
 
-      if ((i+1) % 5 == 0) {
+      if ((i+1) % 100 == 0) {
         std::cout << "Epoch [" << (epoch+1) << "/" << num_epochs << "], Batch: "
           << (i+1) << ", Loss: " << loss.item().toFloat() << std::endl;
       }
+      ++i;
     }
   }
 
   // Test the model
+  model->eval();
   torch::NoGradGuard no_grad;
+
   int correct = 0;
   int total = 0;
   for (const auto& batch : *test_loader) {
-    auto data = batch.data.to(device), labels = batch.target.to(device);
+    auto data = batch.data.reshape({batch_size, -1}).to(device);
+    auto labels = batch.target.to(device);
     auto outputs = model->forward(data);
     auto predicted = outputs.argmax(1);
     total += labels.size(0);
-    correct += predicted.eq(labels).sum().template item<int>();
+    correct += predicted.eq(labels).sum().item<int>();
   }
 
   std::cout << "Accuracy of the model on the 10000 test images: " <<

--- a/tutorials/basics/logistic_regression/main.cpp
+++ b/tutorials/basics/logistic_regression/main.cpp
@@ -23,11 +23,13 @@ int main() {
   int batch_size = 100;
   double learning_rate = 0.001;
 
+  const std::string MNIST_data_path = "../../../../data/mnist/";
+
   // MNIST Dataset (images and labels)
-  auto train_dataset = torch::data::datasets::MNIST("../data")
+  auto train_dataset = torch::data::datasets::MNIST(MNIST_data_path)
                            .map(torch::data::transforms::Normalize<>(0.1307, 0.3081))
                            .map(torch::data::transforms::Stack<>());
-  auto test_dataset = torch::data::datasets::MNIST("../data", torch::data::datasets::MNIST::Mode::kTest)
+  auto test_dataset = torch::data::datasets::MNIST(MNIST_data_path, torch::data::datasets::MNIST::Mode::kTest)
                            .map(torch::data::transforms::Normalize<>(0.1307, 0.3081))
                            .map(torch::data::transforms::Stack<>());
 
@@ -38,7 +40,11 @@ int main() {
           std::move(test_dataset), batch_size);
 
   // Logistic regression model
-  auto model = torch::nn::Linear(input_size, num_classes);
+  auto model = torch::nn::Sequential(
+      torch::nn::Linear(input_size, num_classes),
+      torch::nn::Functional([] (const torch::Tensor& x) { return torch::log_softmax(x, 1); }));
+
+  model->to(device);
 
   // Loss and optimizer
   auto optimizer = torch::optim::SGD(model->parameters(), torch::optim::SGDOptions(learning_rate));
@@ -47,7 +53,8 @@ int main() {
   for (int epoch = 0; epoch < num_epochs; epoch++) {
     int i = 0;
     for (auto& batch : *train_loader) {
-      auto data = batch.data.to(device), labels = batch.target.to(device);
+      auto data = batch.data.reshape({batch_size, -1}).to(device);
+      auto labels = batch.target.to(device);
 
       // Forward pass
       auto outputs = model->forward(data);
@@ -58,23 +65,27 @@ int main() {
       loss.backward();
       optimizer.step();
 
-      if ((i+1) % 5 == 0) {
+      if ((i+1) % 100 == 0) {
         std::cout << "Epoch [" << (epoch+1) << "/" << num_epochs << "], Batch: "
           << (i+1) << ", Loss: " << loss.item().toFloat() << std::endl;
       }
+      ++i;
     }
   }
 
   // Test the model
+  model->eval();
   torch::NoGradGuard no_grad;
+
   int correct = 0;
   int total = 0;
   for (const auto& batch : *test_loader) {
-    auto data = batch.data.to(device), labels = batch.target.to(device);
+    auto data = batch.data.reshape({batch_size, -1}).to(device);
+    auto labels = batch.target.to(device);
     auto outputs = model->forward(data);
     auto predicted = outputs.argmax(1);
     total += labels.size(0);
-    correct += predicted.eq(labels).sum().template item<int>();
+    correct += predicted.eq(labels).sum().item<int>();
   }
 
   std::cout << "Accuracy of the model on the 10000 test images: " <<

--- a/tutorials/intermediate/bidirectional_recurrent_neural_network/src/main.cpp
+++ b/tutorials/intermediate/bidirectional_recurrent_neural_network/src/main.cpp
@@ -20,8 +20,7 @@ int main() {
     const int64_t num_epochs = 2;
     const double learning_rate = 0.003;
 
-    const std::string MNIST_data_path = "../../../../tutorials/intermediate/"
-        "bidirectional_recurrent_neural_network/data/";
+    const std::string MNIST_data_path = "../../../../data/mnist/";
 
     // MNIST dataset
     auto train_dataset = torch::data::datasets::MNIST(MNIST_data_path)

--- a/tutorials/intermediate/convolutional_neural_network/src/main.cpp
+++ b/tutorials/intermediate/convolutional_neural_network/src/main.cpp
@@ -16,7 +16,7 @@ int main() {
     const int64_t batch_size = 100;
     const double learning_rate = 0.001;
 
-    const std::string MNIST_data_path = "../../../../tutorials/intermediate/convolutional_neural_network/data/";
+    const std::string MNIST_data_path = "../../../../data/mnist/";
 
     // MNIST dataset
     auto train_dataset = torch::data::datasets::MNIST(MNIST_data_path)

--- a/tutorials/intermediate/deep_residual_network/include/transform.h
+++ b/tutorials/intermediate/deep_residual_network/include/transform.h
@@ -3,6 +3,7 @@
 
 #include <torch/torch.h>
 #include <random>
+#include <vector>
 
 namespace transform {
 class RandomHorizontalFlip : public torch::data::transforms::TensorTransform<torch::Tensor> {

--- a/tutorials/intermediate/deep_residual_network/src/main.cpp
+++ b/tutorials/intermediate/deep_residual_network/src/main.cpp
@@ -26,7 +26,7 @@ int main() {
     const int64_t learning_rate_decay_frequency = 8;  // number of epochs after which to decay the learning rate
     const double learning_rate_decay_factor = 1.0 / 3.0;
 
-    const std::string CIFAR_data_path = "../../../../tutorials/intermediate/deep_residual_network/data/";
+    const std::string CIFAR_data_path = "../../../../data/cifar10/";
 
     // CIFAR10 custom dataset
     auto train_dataset = CIFAR10(CIFAR_data_path)

--- a/tutorials/intermediate/language_model/src/main.cpp
+++ b/tutorials/intermediate/language_model/src/main.cpp
@@ -27,12 +27,16 @@ int main() {
 
     // Load "Penn Treebank" dataset
     // See https://github.com/yunjey/pytorch-tutorial/blob/master/tutorials/02-intermediate/language_model/data/
-    const std::string penn_treebank_data_path = "../../../../tutorials/intermediate/language_model/data/train.txt";
+    // and https://github.com/wojzaremba/lstm/tree/master/data
+    const std::string penn_treebank_data_path = "../../../../data/penntreebank/train.txt";
 
     Corpus corpus(penn_treebank_data_path);
 
     auto ids = corpus.get_data(batch_size);
     int64_t vocab_size = corpus.get_dictionary().size();
+
+    // Path to the output file
+    const std::string sample_output_path = "../../../../tutorials/intermediate/language_model/data/sample.txt";
 
     // Model
     RNNLM model(vocab_size, embed_size, hidden_size, num_layers);
@@ -90,8 +94,6 @@ int main() {
 
     std::cout << "Training finished!\n\n";
     std::cout << "Generating samples...\n";
-
-    const std::string sample_output_path = "../../../../tutorials/intermediate/language_model/data/sample.txt";
 
     // Generate samples
     model->eval();

--- a/tutorials/intermediate/recurrent_neural_network/src/main.cpp
+++ b/tutorials/intermediate/recurrent_neural_network/src/main.cpp
@@ -20,7 +20,7 @@ int main() {
     const int64_t num_epochs = 2;
     const double learning_rate = 0.01;
 
-    const std::string MNIST_data_path = "../../../../tutorials/intermediate/recurrent_neural_network/data/";
+    const std::string MNIST_data_path = "../../../../data/mnist/";
 
     // MNIST dataset
     auto train_dataset = torch::data::datasets::MNIST(MNIST_data_path)


### PR DESCRIPTION
This adds a function `download_datasets` to the scripts.sh to download all used datasets into a data folder and changes the dataset-paths in the tutorials to point to the downloaded datasets. I had to apply some fixes for some tutorial files, such as reshaping the batches in some of the basic tutorials.

Also, I added an optional  `--cuda=...` parameter to the install function which can be used to download the gpu versions (CUDA 9.2 or 10.1) of libtorch alternatively. 

Finally, I added descriptions for these new functions in the README.

Let me know what you think!