### PR TITLE
Add tensor slicing examples to pytorch-basics tutorial.

### DIFF
--- a/tutorials/basics/pytorch_basics/main.cpp
+++ b/tutorials/basics/pytorch_basics/main.cpp
@@ -114,17 +114,27 @@ int main() {
     std::vector<int64_t> test_data = {1, 2, 3, 4, 5, 6, 7, 8, 9};
     torch::Tensor s = torch::from_blob(test_data.data(), {3, 3}, torch::kInt64);
     std::cout << "s:\n" << s << '\n';
+    // Output:
+    // 1 2 3
+    // 4 5 6
+    // 7 8 9
 
     // Extract a single element tensor:
     std::cout << "\"s[0,2]\" as tensor:\n" << s[0][2] << '\n';
     std::cout << "\"s[0,2]\" as value:\n" << s[0][2].item<int64_t>() << '\n';
+    // Output:
+    // 3
 
     // select(dim, index):
-    // - Slice a tensor along a dimension at a given index
+    // - Slice a tensor along a dimension at a given index.
     //
     // Function definition can be found at:
     // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp#L736
     std::cout << "\"s[:,2]\":\n" << s.select(1, 2) << '\n';
+    // Output:
+    // 3
+    // 6
+    // 9
 
     // slice(dim, start=0, end=<maximum int64_t value>, step=1):
     // - Slice a tensor along a dimension at given indices from
@@ -133,11 +143,25 @@ int main() {
     // Function definition can be found at:
     // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp#L856
     std::cout << "\"s[:2,:]\":\n" << s.slice(0, 0, 2) << '\n';
+    // Output:
+    // 1 2 3
+    // 4 5 6
     std::cout << "\"s[:,1:]\":\n" << s.slice(1, 1) << '\n';
+    // Output:
+    // 2 3
+    // 5 6
+    // 8 9
     std::cout << "\"s[:,::2]\":\n" << s.slice(1, 0, s.size(1), 2) << '\n';
+    // Output:
+    // 1 3
+    // 4 6
+    // 7 9
 
     // Combining select() and slice():
     std::cout << "\"s[:2,1]\":\n" << s.slice(0, 0, 2).select(1, 1) << "\n\n";
+    // Output:
+    // 2
+    // 5
 
     // =============================================================== //
     //                         INPUT PIPELINE                          //

--- a/tutorials/basics/pytorch_basics/main.cpp
+++ b/tutorials/basics/pytorch_basics/main.cpp
@@ -106,6 +106,40 @@ int main() {
     TORCH_CHECK(data_vector.data() == t2.data_ptr<float>());
 
     // =============================================================== //
+    //             SLICING AND EXTRACTING PARTS FROM TENSORS           //
+    // =============================================================== //
+
+    std::cout << "---- SLICING AND EXTRACTING PARTS FROM TENSORS ----\n";
+
+    std::vector<int64_t> test_data = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    torch::Tensor s = torch::from_blob(test_data.data(), {3, 3}, torch::kInt64);
+    std::cout << "s:\n" << s << '\n';
+
+    // Extract a single element tensor:
+    std::cout << "\"s[0,2]\" as tensor:\n" << s[0][2] << '\n';
+    std::cout << "\"s[0,2]\" as value:\n" << s[0][2].item<int64_t>() << '\n';
+
+    // select(dim, index):
+    // - Slice a tensor along a dimension at a given index
+    //
+    // Function definition can be found at:
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp#L736
+    std::cout << "\"s[:,2]\":\n" << s.select(1, 2) << '\n';
+
+    // slice(dim, start=0, end=<maximum int64_t value>, step=1):
+    // - Slice a tensor along a dimension at given indices from
+    //   "start" up to - but not including - "end" using step size "step".
+    //
+    // Function definition can be found at:
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/TensorShape.cpp#L856
+    std::cout << "\"s[:2,:]\":\n" << s.slice(0, 0, 2) << '\n';
+    std::cout << "\"s[:,1:]\":\n" << s.slice(1, 1) << '\n';
+    std::cout << "\"s[:,::2]\":\n" << s.slice(1, 0, s.size(1), 2) << '\n';
+
+    // Combining select() and slice():
+    std::cout << "\"s[:2,1]\":\n" << s.slice(0, 0, 2).select(1, 1) << "\n\n";
+
+    // =============================================================== //
     //                         INPUT PIPELINE                          //
     // =============================================================== //
 

--- a/tutorials/intermediate/bidirectional_recurrent_neural_network/src/bi_rnn.cpp
+++ b/tutorials/intermediate/bidirectional_recurrent_neural_network/src/bi_rnn.cpp
@@ -18,9 +18,9 @@ torch::Tensor BiRNNImpl::forward(torch::Tensor x) {
     // https://github.com/yunjey/pytorch-tutorial/pull/174/commits/8c0897ee93fed8d9b352d33a60c1f931c9be5351
     auto out_directions = out.chunk(2, 2);
     // Last hidden state of forward direction output
-    auto out_1 = out_directions[0].slice(1, -1).squeeze(1);  // out_1: tensor of shape (batch_size, hidden_size)
+    auto out_1 = out_directions[0].select(1, -1);  // out_1: tensor of shape (batch_size, hidden_size)
     // First hidden state of backward direction output
-    auto out_2 = out_directions[1].slice(1, 0, 1).squeeze(1);  // out_2: tensor of shape (batch_size, hidden_size)
+    auto out_2 = out_directions[1].select(1, 0);  // out_2: tensor of shape (batch_size, hidden_size)
     auto out_cat = torch::cat({out_1, out_2}, 1);  // out_cat: tensor of shape (batch_size, 2 * hidden_size)
 
     return fc->forward(out_cat);

--- a/tutorials/intermediate/recurrent_neural_network/src/rnn.cpp
+++ b/tutorials/intermediate/recurrent_neural_network/src/rnn.cpp
@@ -10,9 +10,6 @@ RNNImpl::RNNImpl(int64_t input_size, int64_t hidden_size, int64_t num_layers, in
 }
 
 torch::Tensor RNNImpl::forward(torch::Tensor x) {
-    auto out = lstm->forward(x)
-        .output
-        .slice(1, -1)
-        .squeeze(1);
+    auto out = lstm->forward(x).output.select(1, -1);
     return fc->forward(out);
 }


### PR DESCRIPTION
This adds a section containing tensor slicing examples to the pytorch-basics tutorial and simplifies some slicing operations in other tutorials.