### PR TITLE
Fix neural style transfer scripmodule creation script error

### DIFF
--- a/tutorials/advanced/neural_style_transfer/model/create_vgg19_layers_scriptmodule.py
+++ b/tutorials/advanced/neural_style_transfer/model/create_vgg19_layers_scriptmodule.py
@@ -9,9 +9,13 @@ def main():
     for param in vgg_19_layers.parameters():
         param.requires_grad = False
 
+    example = torch.rand(1, 3, 224, 224)
+
+    traced_script_module = torch.jit.trace(vgg_19_layers, example)
+
     # Serialize scriptmodule to a file.
     filename = "vgg19_layers.pt"
-    vgg_19_layers.save(filename)
+    traced_script_module.save(filename)
     print(f"Successfully created scriptmodule file {filename}.")
 
 


### PR DESCRIPTION
Fixes #47. 

*Cause of error*: `save()` was wrongly called on the `Sequential` instead of creating a scriptmodule and calling `save()` on that.