### PR TITLE
Build and link image utils as libraries in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory("tutorials/intermediate/bidirectional_recurrent_neural_network"
 add_subdirectory("tutorials/intermediate/language_model")
 
 # Advanced
+add_subdirectory("tutorials/advanced/utils")
 add_subdirectory("tutorials/advanced/generative_adversarial_network")
 add_subdirectory("tutorials/advanced/variational_autoencoder")
 add_subdirectory("tutorials/advanced/neural_style_transfer")

--- a/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
+++ b/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
@@ -10,16 +10,9 @@ endif()
 set(EXECUTABLE_NAME generative-adversarial-network)
 
 add_executable(${EXECUTABLE_NAME})
-target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/src/save_image.cpp
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/save_image.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external/stb_image_write.h
-)
+target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 
-target_include_directories(${EXECUTABLE_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include
-                                                      ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external)
-
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}" save-image)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 14

--- a/tutorials/advanced/neural_style_transfer/CMakeLists.txt
+++ b/tutorials/advanced/neural_style_transfer/CMakeLists.txt
@@ -12,20 +12,11 @@ set(EXECUTABLE_NAME neural-style-transfer)
 add_executable(${EXECUTABLE_NAME})
 target_sources(${EXECUTABLE_NAME} PRIVATE src/main.cpp
                                           src/vggnet.cpp
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/src/save_image.cpp
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/src/load_image.cpp
                                           include/vggnet.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/save_image.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/load_image.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external/stb_image_write.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external/stb_image.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external/stb_image_resize.h
 )
-target_include_directories(${EXECUTABLE_NAME} PRIVATE include
-                                                      ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include
-                                                      ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external)
+target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}" save-image load-image)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 14

--- a/tutorials/advanced/utils/CMakeLists.txt
+++ b/tutorials/advanced/utils/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(image-utils VERSION 1.0.0 LANGUAGES CXX)
+
+if(NOT Torch_FOUND)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
+    find_package(Torch REQUIRED PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../../libtorch")
+endif()
+
+add_library(load-image SHARED)
+target_sources(load-image PRIVATE include/external/stb_image.h
+                                  include/external/stb_image_resize.h
+                          PUBLIC src/load_image.cpp
+                                 include/load_image.h)
+                          
+target_include_directories(load-image PUBLIC include 
+                                             include/external)
+
+target_link_libraries(load-image ${TORCH_LIBRARIES})
+
+set_target_properties(load-image PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED YES
+)
+                                
+add_library(save-image SHARED)
+target_sources(save-image PRIVATE include/external/stb_image_write.h
+                          PUBLIC src/save_image.cpp
+                                 include/save_image.h)
+                          
+target_include_directories(save-image PUBLIC include 
+                                             include/external)
+
+target_link_libraries(save-image ${TORCH_LIBRARIES})
+
+set_target_properties(save-image PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED YES
+)

--- a/tutorials/advanced/variational_autoencoder/CMakeLists.txt
+++ b/tutorials/advanced/variational_autoencoder/CMakeLists.txt
@@ -12,16 +12,11 @@ set(EXECUTABLE_NAME variational-autoencoder)
 add_executable(${EXECUTABLE_NAME})
 target_sources(${EXECUTABLE_NAME} PRIVATE src/main.cpp
                                           src/variational_autoencoder.cpp
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/src/save_image.cpp
                                           include/variational_autoencoder.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/save_image.h
-                                          ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external/stb_image_write.h
 )
-target_include_directories(${EXECUTABLE_NAME} PRIVATE include
-                                                      ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include
-                                                      ${CMAKE_CURRENT_SOURCE_DIR}/../utils/include/external)
+target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 
-target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}")
+target_link_libraries(${EXECUTABLE_NAME} "${TORCH_LIBRARIES}" save-image)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
   CXX_STANDARD 14


### PR DESCRIPTION
Adds a CMake step to build image-utils (image loading & saving) as shared libraries and links them with tutorials that require them. This makes it possible to reuse image-utils functionality in different (present and possible future) tutorials without recompiling the headers/sources and explicitly adding every necessary file for each one.