### PR TITLE
Upgrade to libtorch v1.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 option(DOWNLOAD_DATASETS "Download datasets used in the tutorials." ON)
 
-set(PYTORCH_VERSION "1.5.1")
+set(PYTORCH_VERSION "1.6.0")
 
 find_package(Torch ${PYTORCH_VERSION} EXACT QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
     <br />
 <img src="https://img.shields.io/travis/prabhuomkar/pytorch-cpp">
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-1.5.1-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-1.6.0-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\libtorch |                                                  1.5.1                                                  |  nightly |
+| OS (Compiler)\\libtorch |                                                  1.6.0                                                  |  nightly |
 | :---------------------: | :---------------------------------------------------------------------------------------------------: |  :-----: |
 |    macOS (clang 9.1)    | ![Status](https://travis-matrix-badges.herokuapp.com/repos/prabhuomkar/pytorch-cpp/branches/master/1) |          |
 |    macOS (clang 10.0)   | ![Status](https://travis-matrix-badges.herokuapp.com/repos/prabhuomkar/pytorch-cpp/branches/master/2) |          |
@@ -31,7 +31,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++](http://www.cplusplus.com/doc/tutorial/introduction/)
 2. [CMake](https://cmake.org/download/)
-3. [LibTorch v1.5.1](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch v1.6.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -68,7 +68,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(9.2\|10.1\|10.2\|none)`     | `none` | Download libtorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(9.2 [Linux only]\|10.1\|10.2\|none)`     | `none` | Download libtorch for a CUDA version (`none` = download CPU version). |
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download all datasets used in the tutorials. |
 | `-D CMAKE_PREFIX_PATH=path/to/libtorch/share/cmake/Torch` |   `<empty>`    |    Skip the downloading of libtorch and use your own local version (see Requirements) instead. |
 | `-D CMAKE_BUILD_TYPE=(Release\|Debug)` | `<empty>` (`Release` when downloading libtorch on Windows) | Set the build type (`Release` = compile with optimizations)|

--- a/cmake/download_libtorch.cmake
+++ b/cmake/download_libtorch.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (9.2, 10.1 or 10.2).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (9.2 [Linux only], 10.1 or 10.2).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
@@ -13,7 +13,7 @@ elseif(${CUDA_V} STREQUAL "10.1")
 elseif(${CUDA_V} STREQUAL "10.2")
     set(LIBTORCH_DEVICE "cu102")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 9.2, 10.1, 10.2 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 9.2 [Linux only], 10.1, 10.2 or none!")
 endif()
 
 if(NOT ${LIBTORCH_DEVICE} STREQUAL "cu102")
@@ -21,6 +21,10 @@ if(NOT ${LIBTORCH_DEVICE} STREQUAL "cu102")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    if(${LIBTORCH_DEVICE} STREQUAL "cu92")
+        message(FATAL_ERROR "PyTorch ${PYTORCH_VERSION} does not support CUDA 9.2 on Windows. Please use CPU or upgrade to CUDA versions 10.1 or 10.2.")
+    endif()
+
     set(LIBTORCH_URL "https://download.pytorch.org/libtorch/${LIBTORCH_DEVICE}/libtorch-win-shared-with-deps-${PYTORCH_VERSION}${LIBTORCH_DEVICE_TAG}.zip")
     set(CMAKE_BUILD_TYPE "Release")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/tutorials/advanced/image_captioning/src/score.cpp
+++ b/tutorials/advanced/image_captioning/src/score.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-present pytorch-cpp Authors
 #include "score.h"
 #include <vector>
+#include <cmath>
 
 namespace score {
 namespace {
@@ -9,20 +10,20 @@ torch::Tensor n_grams(const torch::Tensor &sequence, size_t n) {
            torch::empty({0}, sequence.options()) : sequence.unfold(-1, n, 1);
 }
 
-size_t closest_reference_size(size_t hypothesis_size, const std::vector<torch::Tensor> &references) {
-    std::vector<size_t> reference_sizes(references.size());
+int64_t closest_reference_size(int64_t hypothesis_size, const std::vector<torch::Tensor> &references) {
+    std::vector<int64_t> reference_sizes(references.size());
 
     std::transform(references.cbegin(), references.cend(), reference_sizes.begin(),
                    [](const auto &reference) { return reference.size(0); });
 
     return *std::min_element(reference_sizes.cbegin(), reference_sizes.cend(),
-                             [hypothesis_size](auto l, auto r) {
-                                 return std::abs<int64_t>(l - hypothesis_size) <=
-                                        std::abs<int64_t>(r - hypothesis_size);
+                             [hypothesis_size](int64_t l, int64_t r) {
+                                 return std::abs(l - hypothesis_size) <=
+                                        std::abs(r - hypothesis_size);
                              });
 }
 
-double brevity_penalty(size_t hypothesis_size, size_t closest_ref_size) {
+double brevity_penalty(int64_t hypothesis_size, int64_t closest_ref_size) {
     return (hypothesis_size > closest_ref_size) ? 1.0 :
            std::exp(1.0 - static_cast<double>(closest_ref_size) / hypothesis_size);
 }


### PR DESCRIPTION
Upgrades to the latest libtorch version [v1.6.0](https://github.com/pytorch/pytorch/releases/tag/v1.6.0), which  required just some minor code changes.
Also, I removed the possibility to download libtorch for CUDA 9.2 on Windows via CMake as the binaries are no longer provided.
