### PR TITLE
Build and run tutorials in Docker container on CPU

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+/data
+/build
+/images
+/LICENSE
+/AUTHORS
+/notebooks
+/README.md
+/docker-compose.yml
+/Dockerfile
+/.github
+/.gitignore
+/.dockerignore
+/.travis.yml
+/.git

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force bash scripts to always use LF line endings.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Based on and inspired by Dockerfiles and resources at:
+#   https://github.com/pytorch/pytorch/blob/master/Dockerfile
+#   https://github.com/anibali/docker-pytorch
+#   https://jtreminio.com/blog/running-docker-containers-as-current-host-user/
+
+ARG BASE_IMAGE=ubuntu:18.04
+ARG PYTHON_VERSION=3.8
+
+FROM ${BASE_IMAGE} AS dev-base
+# Install basic packages.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    ca-certificates && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+ENV PATH /opt/conda/bin:$PATH
+
+FROM dev-base AS conda
+ARG PYTHON_VERSION
+# Install conda.
+ENV CONDA_AUTO_UPDATE_CONDA=false
+RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
+    chmod +x ~/miniconda.sh && \
+    ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    conda install -y python=${PYTHON_VERSION} && \
+    conda clean -ya
+
+FROM conda AS conda-installs
+ARG PYTORCH_VERSION=1.6.0
+ARG TORCHVISION_VERSION=0.7.0
+# Install pytorch for cpu and torchvision.
+ENV NO_CUDA=1
+RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
+
+FROM conda AS build
+ARG PYTHON_VERSION
+ARG GROUP_ID=1000
+ARG USER_ID=1000
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+# Build the tutorials.
+WORKDIR /pytorch-cpp
+# INstall
+RUN pip install --upgrade --no-cache-dir cmake && \
+    groupadd --gid ${GROUP_ID} user && \
+    useradd --uid ${USER_ID} --gid user  --create-home --no-log-init --shell /bin/bash user && \
+    chown --changes --silent --no-dereference --recursive ${USER_ID}:${GROUP_ID} /home/user
+USER user
+ENV HOME=/home/user
+COPY --from=conda-installs /opt/conda /opt/conda
+COPY --chown=user:user ./docker/docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && \
 ENV PATH /opt/conda/bin:$PATH
 
 FROM dev-base AS conda
-ARG PYTHON_VERSION
 # Install conda.
+ARG PYTHON_VERSION
 ENV CONDA_AUTO_UPDATE_CONDA=false
 RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
     chmod +x ~/miniconda.sh && \
@@ -30,20 +30,19 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
     conda clean -ya
 
 FROM conda AS conda-installs
+# Install pytorch for CPU and torchvision.
 ARG PYTORCH_VERSION=1.6.0
 ARG TORCHVISION_VERSION=0.7.0
-# Install pytorch for cpu and torchvision.
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
 
 FROM conda AS build
+# Build tutorials.
 ARG PYTHON_VERSION
 ARG GROUP_ID=1000
 ARG USER_ID=1000
 ENV PYTHON_VERSION=${PYTHON_VERSION}
-# Build the tutorials.
 WORKDIR /pytorch-cpp
-# INstall
 RUN pip install --upgrade --no-cache-dir cmake && \
     groupadd --gid ${GROUP_ID} user && \
     useradd --uid ${USER_ID} --gid user  --create-home --no-log-init --shell /bin/bash user && \

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can build and run the tutorials (on CPU) in a Docker container using the pro
     docker-compose build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)
     ```
     > **_Note_**:  
-    > When you run the Docker container, the host repo directory is mounted as a volume in the Docker container in order to cache build and downloaded dependency files so that it is not necessary to rebuild or redownload everything when a container is restarted. In order to have correct file permissions it is necessary to provide your user and group ids as build arguments when building the image.
+    > When you run the Docker container, the host repo directory is mounted as a volume in the Docker container in order to cache build and downloaded dependency files so that it is not necessary to rebuild or redownload everything when a container is restarted. In order to have correct file permissions it is necessary to provide your user and group ids as build arguments when building the image on Linux.
 2. Now start the container and build the tutorials using:
     ```bash
     docker-compose run --rm pytorch-cpp

--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ cmake --build build
      .\pytorch-basics.exe
      # In general: .\{tutorial-name}.exe
      ```
+
+### Using Docker
+You can build and run the tutorials (on CPU) in a Docker container using the provided `Dockerfile` and `docker-compose.yml` files:  
+1. From the root directory of the cloned repo build the image:
+    ```bash
+    docker-compose build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)
+    ```
+    > **_Note_**:  
+    > When you run the Docker container, the host repo directory is mounted as a volume in the Docker container in order to cache build and downloaded dependency files so that it is not necessary to rebuild or redownload everything when a container is restarted. In order to have correct file permissions it is necessary to provide your user and group ids as build arguments when building the image.
+2. Now start the container and build the tutorials using:
+    ```bash
+    docker-compose run --rm pytorch-cpp
+    ```
+    This fetches all necessary dependencies and builds the tutorials. After the build is done, by default the container starts `bash` in interactive mode in the `build/tutorials` folder. 
+    As an alternative, you can also directly run a tutorial by instead invoking the above command with the tutorial as additional argument, for example:
+    ```bash
+    docker-compose run --rm pytorch-cpp pytorch-basics
+    # In general: docker-compose run --rm pytorch-cpp {tutorial-name} 
+    ```
+    This will - if necessary - build all tutorials and then start the provided tutorial in a container.
+
 ## Table of Contents
 
 ### 1. Basics

--- a/cmake/download_flickr8k.cmake
+++ b/cmake/download_flickr8k.cmake
@@ -21,7 +21,9 @@ if(NOT EXISTS ${FLICKR8K_TEXT_SOURCE_DIR} OR NOT EXISTS ${FLICKR8K_DATA_SOURCE_D
     )
 
     FetchContent_MakeAvailable(flickr_8k_text)
+    
     set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+
     FetchContent_Declare(
         flickr_8k_data
         DOWNLOAD_DIR ${FLICKR8K_DIR}/download
@@ -30,6 +32,8 @@ if(NOT EXISTS ${FLICKR8K_TEXT_SOURCE_DIR} OR NOT EXISTS ${FLICKR8K_DATA_SOURCE_D
     )
 
     FetchContent_MakeAvailable(flickr_8k_data)
+
+    set(FETCHCONTENT_QUIET ON CACHE BOOL "" FORCE)
 
     file(REMOVE_RECURSE "${FLICKR8K_DIR}/download")
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  pytorch-cpp:
+    build: .
+    volumes:
+      - .:/pytorch-cpp
+    image: pytorch-cpp
+    ipc: host
+    container_name: pytorch-cpp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,4 @@ services:
     volumes:
       - .:/pytorch-cpp
     image: pytorch-cpp
-    ipc: host
     container_name: pytorch-cpp

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+cmake -B build -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_PREFIX_PATH=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch/share/cmake/Torch/ \
+    -D CREATE_SCRIPTMODULES=ON
+cmake --build build --parallel 4
+cd build/tutorials
+
+tutorial_path=$(find . -maxdepth 2 -mindepth 2 -type d -name $(echo $1 | tr - _))
+
+if [ ! -z "$tutorial_path" ]
+then
+    cd $tutorial_path
+    ./$(echo $(basename $tutorial_path) | tr _ -) ${@:2}
+else
+    exec $@
+fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -Eeo pipefail
 cmake -B build -D CMAKE_BUILD_TYPE=Release \
     -D CMAKE_PREFIX_PATH=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/torch/share/cmake/Torch/ \
     -D CREATE_SCRIPTMODULES=ON
-cmake --build build --parallel 4
+cmake --build build
 cd build/tutorials
 
 tutorial_path=$(find . -maxdepth 2 -mindepth 2 -type d -name $(echo $1 | tr - _))


### PR DESCRIPTION
This adds the option to build and run the tutorials in a container (on CPU) using Docker and docker-compose.

**Features**:
* Added multi-stage Dockerfile, docker-compose.yml and .dockerignore.
* Entrypoint-script that allows to run the tutorials in a Docker container by simply appending the tutorial name to the `docker-compose run ...` command.
* Usage description in the README (after the local build description).