### PR TITLE
Upgrade to libtorch v1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "1.6.0")
+set(PYTORCH_VERSION "1.7.0")
 
 find_package(Torch ${PYTORCH_VERSION} EXACT QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
     <br />
 <img src="https://img.shields.io/travis/prabhuomkar/pytorch-cpp">
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-1.6.0-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-1.7.0-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  1.6.0                                                  |  nightly |
+| OS (Compiler)\\LibTorch |                                                  1.7.0                                                  |  nightly |
 | :---------------------: | :---------------------------------------------------------------------------------------------------: |  :-----: |
 |    macOS (clang 9.1)    | ![Status](https://travis-matrix-badges.herokuapp.com/repos/prabhuomkar/pytorch-cpp/branches/master/1) |          |
 |    macOS (clang 10.0)   | ![Status](https://travis-matrix-badges.herokuapp.com/repos/prabhuomkar/pytorch-cpp/branches/master/2) |          |
@@ -58,7 +58,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++](http://www.cplusplus.com/doc/tutorial/introduction/)
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
-3. [LibTorch v1.6.0](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch v1.7.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -95,7 +95,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(9.2 [Linux only]\|10.1\|10.2\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(9.2 [Linux only]\|10.1\|10.2\|11.0\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |
 | `-D CMAKE_PREFIX_PATH=path/to/libtorch/share/cmake/Torch` |   `<empty>`    |    Skip the downloading of LibTorch and use your own local version (see [Requirements](#requirements)) instead. |

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (9.2 [Linux only], 10.1 or 10.2).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (9.2 [Linux only], 10.1, 10.2 or 11.0).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
@@ -12,8 +12,10 @@ elseif(${CUDA_V} STREQUAL "10.1")
     set(LIBTORCH_DEVICE "cu101")
 elseif(${CUDA_V} STREQUAL "10.2")
     set(LIBTORCH_DEVICE "cu102")
+elseif(${CUDA_V} STREQUAL "11.0")
+    set(LIBTORCH_DEVICE "cu110")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 9.2 [Linux only], 10.1, 10.2 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 9.2 [Linux only], 10.1, 10.2, 11.0 or none!")
 endif()
 
 if(NOT ${LIBTORCH_DEVICE} STREQUAL "cu102")
@@ -22,7 +24,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     if(${LIBTORCH_DEVICE} STREQUAL "cu92")
-        message(FATAL_ERROR "PyTorch ${PYTORCH_VERSION} does not support CUDA 9.2 on Windows. Please use CPU or upgrade to CUDA versions 10.1 or 10.2.")
+        message(FATAL_ERROR "PyTorch ${PYTORCH_VERSION} does not support CUDA 9.2 on Windows. Please use CPU or upgrade to CUDA versions 10.1, 10.2 or 11.0.")
     endif()
 
     set(LIBTORCH_URL "https://download.pytorch.org/libtorch/${LIBTORCH_DEVICE}/libtorch-win-shared-with-deps-${PYTORCH_VERSION}${LIBTORCH_DEVICE_TAG}.zip")


### PR DESCRIPTION
## Description of the change

* Upgrades to libtorch version [1.7.0](https://github.com/pytorch/pytorch/releases/tag/v1.7.0). 
* No code changes. 
* Adds option to download libtorch 1.7.0 for CUDA 11.0 via CMake and updates README.

## Type Of Change
- [x] Dependency version upgrade

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
