### PR TITLE
Upgrade CMake C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(${EXECUTABLE_NAME})
 target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 ## Requirements
 
-1. [C++](http://www.cplusplus.com/doc/tutorial/introduction/)
+1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
 3. [LibTorch v1.9.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -11,7 +11,7 @@ FetchContent_Declare(
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cxxopts
 )
 
-set(CXXOPTS_CXX_STANDARD 14)
+set(CXXOPTS_CXX_STANDARD 17)
 set(CXXOPTS_BUILD_EXAMPLES OFF CACHE BOOL "Set to ON to build examples" FORCE)
 set(CXXOPTS_BUILD_TESTS OFF CACHE BOOL "Set to ON to build tests" FORCE)
 set(CXXOPTS_ENABLE_INSTALL OFF CACHE BOOL "Generate the install target" FORCE)

--- a/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
+++ b/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES} image-io)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/advanced/image_captioning/CMakeLists.txt
+++ b/tutorials/advanced/image_captioning/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES} image-io cxxopts)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/advanced/neural_style_transfer/CMakeLists.txt
+++ b/tutorials/advanced/neural_style_transfer/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES} image-io)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/advanced/variational_autoencoder/CMakeLists.txt
+++ b/tutorials/advanced/variational_autoencoder/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES} image-io)
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/basics/feedforward_neural_network/CMakeLists.txt
+++ b/tutorials/basics/feedforward_neural_network/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/basics/linear_regression/CMakeLists.txt
+++ b/tutorials/basics/linear_regression/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/basics/logistic_regression/CMakeLists.txt
+++ b/tutorials/basics/logistic_regression/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/basics/pytorch_basics/CMakeLists.txt
+++ b/tutorials/basics/pytorch_basics/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/intermediate/bidirectional_recurrent_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/bidirectional_recurrent_neural_network/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/intermediate/convolutional_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/convolutional_neural_network/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/intermediate/deep_residual_network/CMakeLists.txt
+++ b/tutorials/intermediate/deep_residual_network/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/intermediate/language_model/CMakeLists.txt
+++ b/tutorials/intermediate/language_model/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/intermediate/recurrent_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/recurrent_neural_network/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/popular/blitz/autograd/CMakeLists.txt
+++ b/tutorials/popular/blitz/autograd/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/popular/blitz/neural_networks/CMakeLists.txt
+++ b/tutorials/popular/blitz/neural_networks/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/popular/blitz/tensors/CMakeLists.txt
+++ b/tutorials/popular/blitz/tensors/CMakeLists.txt
@@ -10,7 +10,7 @@ target_sources(${EXECUTABLE_NAME} PRIVATE main.cpp)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 

--- a/tutorials/popular/blitz/training_a_classifier/CMakeLists.txt
+++ b/tutorials/popular/blitz/training_a_classifier/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE include)
 target_link_libraries(${EXECUTABLE_NAME} ${TORCH_LIBRARIES})
 
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )
 


### PR DESCRIPTION
## Description of the change
* Upgrades C++ version from 14 to 17 in all CMake configuration files.
* Updates C++ requirement note in README.

## Type Of Change
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature
- [ ] New PyTorch tutorial
- [x] Breaking Change (loss of support for older compilers that are incompatible with c++17)

## Related Issues

Closes #90 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`) No code changes.
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
