### PR TITLE
Upgrade to libtorch v1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "1.10.1")
+set(PYTORCH_VERSION "1.12.0")
 
 find_package(Torch ${PYTORCH_VERSION} EXACT QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
 
 FROM conda AS conda-installs
 # Install pytorch for CPU and torchvision.
-ARG PYTORCH_VERSION=1.10.1
-ARG TORCHVISION_VERSION=0.11.2
+ARG PYTORCH_VERSION=1.12.0
+ARG TORCHVISION_VERSION=0.13.0
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
     C++ Implementation of PyTorch Tutorials for Everyone
     <br />
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-1.10.1-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-1.12.0-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  1.10.1                                                |
+| OS (Compiler)\\LibTorch |                                                  1.12.0                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
 |    macOS (clang 11.0, 12.0)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
 |      Linux (gcc 8, 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
@@ -52,7 +52,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
-3. [LibTorch v1.10.1](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch v1.12.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(10.2\|11.1\|11.3\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.3\|11.6\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |
@@ -116,14 +116,14 @@ cmake -B build \
 <summary><b>Example Windows</b></summary>
 
 ##### Aim
-* Automatically download LibTorch for CUDA 11.3 (Release version) and all necessary datasets.
+* Automatically download LibTorch for CUDA 11.6 (Release version) and all necessary datasets.
 * Do not create scriptmodule files.
 
 ##### Command
 ```bash
 cmake -B build \
 -A x64 \
--D CUDA_V=11.3
+-D CUDA_V=11.6
 ```
 </details>
 

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,18 +2,16 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (10.2, 11.1, 11.3 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.3, 11.6 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
-elseif(${CUDA_V} STREQUAL "10.2")
-    set(LIBTORCH_DEVICE "cu102")
-elseif(${CUDA_V} STREQUAL "11.1")
-    set(LIBTORCH_DEVICE "cu111")
 elseif(${CUDA_V} STREQUAL "11.3")
     set(LIBTORCH_DEVICE "cu113")
+elseif(${CUDA_V} STREQUAL "11.6")
+    set(LIBTORCH_DEVICE "cu116")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 10.2, 11.1, 11.3 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.3, 11.6 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")


### PR DESCRIPTION
## Description of the change
* Upgrades libtorch to 1.12.0 in CMake and Docker setup.
* Updates available CUDA version  options (11.3 and 11.6) for libtorch download via CMake.

## Type Of Change
- [x] New Feature

## Related Issues

Closes #97 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
