### PR TITLE
Update CI runner settings

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -18,11 +18,11 @@ on:
 
 jobs:
   build-mac:
-    name: "Macos 10.15 Xcode (Clang)"
-    runs-on: macos-10.15
+    name: "Macos 11.7 Xcode (Clang)"
+    runs-on: macos-11
     strategy:
       matrix:
-        xcode: [11.5, 12.4]
+        xcode: [11.7, 12.4, 13.2.1]
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -25,9 +25,9 @@ jobs:
         xcode: [11.7, 12.4, 13.2.1]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v3
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: '3.14.0'
     - name: Set up Xcode

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        gcc: [8, 9, 10, 11]
+        gcc: [9, 10, 11]
     steps:
     - name: Checkout
       uses: actions/checkout@v2.0.0

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -25,9 +25,9 @@ jobs:
         gcc: [9, 10, 11]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v3
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13
       with:
         cmake-version: '3.14.0'
     - name: Set up GCC

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -25,12 +25,12 @@ jobs:
         config:
         - {
             name: Windows MSVC 2019,
-            os: windows-2019
+            os: windows-2019,
             cmake: '3.14.0'
           }
         - {
             name: Windows MSVC 2022,
-            os: windows-2022
+            os: windows-2022,
             cmake: '3.24.2'
           }
     steps:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         config:
         - {
-            name: Windows MSVC 2017,
-            os: windows-2016
-          }
-        - {
             name: Windows MSVC 2019,
             os: windows-2019
+          }
+        - {
+            name: Windows MSVC 2022,
+            os: windows-2022
           }
     steps:
     - name: Checkout

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -26,18 +26,20 @@ jobs:
         - {
             name: Windows MSVC 2019,
             os: windows-2019
+            cmake: '3.14.0'
           }
         - {
             name: Windows MSVC 2022,
             os: windows-2022
+            cmake: '3.24.2'
           }
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.0.0
+      uses: actions/checkout@v3
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v1.9
+      uses: jwlawson/actions-setup-cmake@v1.13
       with:
-        cmake-version: '3.14.0'
+        cmake-version: ${{ matrix.config.cmake }}
     - name: Cpplint
       run: cmake -P cmake/cpplint.cmake
     - name: Configure

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 | OS (Compiler)\\LibTorch |                                                  1.12.0                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
-|    macOS (clang 11.0, 12.0)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
-|      Linux (gcc 8, 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
-|    Windows (msvc 2017, 2019)  | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_windows.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-windows) |
+|    macOS (clang 11, 12, 13)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
+|      Linux (gcc 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
+|    Windows (msvc 2019, 2022)  | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_windows.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-windows) |
 
 ## Table of Contents
 


### PR DESCRIPTION
## Description of the change

* Updates CI Macos runner to `macos-11` (= current `macos-latest`) as `macos-10.15` runner is deprecated. Updates compatible xcode versions in matrix setup; also adds xcode 13 (clang 13) build.
* Removes CI Ubuntu GCC 8 build due to potential problems with `std::filesystem`.
* Replaces no longer available CI Windows runner `windows-2016` with `window-2022` runner. For the `windows-2022` runner, a more recent CMake version is used as older versions do not support the `Visual Studio 17 2022` generator.
* Updates deprecated Github actions `checkout` and `setup-cmake` to latest versions (this removes the deprecation warnings in Actions).
* Updates README build table to reflect changes.

## Type Of Change
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature
- [ ] New PyTorch tutorial
- [ ] Breaking Change (cmake changes, fix or feature that would cause existing functionality to not work as expected)
- [x] CI workflow update/fix.

## Related Issues

Closes #102 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`) [no code changes]
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
