### PR TITLE
Upgrade to libtorch v1.13.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,19 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "1.12.0")
+set(PYTORCH_VERSION "1.13.1")
+set(PYTORCH_MIN_VERSION "1.12.0")
 
-find_package(Torch ${PYTORCH_VERSION} EXACT QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")
+find_package(Torch QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")
 
-if(NOT Torch_FOUND)
+if((NOT Torch_FOUND) OR (("${Torch_VERSION}" VERSION_LESS "${PYTORCH_MIN_VERSION}") OR
+                         ("${Torch_VERSION}" VERSION_GREATER "${PYTORCH_VERSION}")))
     unset(Torch_FOUND)
+    message(STATUS "Could not find compatible Torch version (>= ${PYTORCH_MIN_VERSION}, <= ${PYTORCH_VERSION})")
     include(fetch_libtorch)
 endif()
+
+message(STATUS "Torch version ${Torch_VERSION}")
 
 if(CREATE_SCRIPTMODULES)
     find_package(Python3 COMPONENTS Interpreter REQUIRED)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
 
 FROM conda AS conda-installs
 # Install pytorch for CPU and torchvision.
-ARG PYTORCH_VERSION=1.12.0
-ARG TORCHVISION_VERSION=0.13.0
+ARG PYTORCH_VERSION=1.13.1
+ARG TORCHVISION_VERSION=0.14.1
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
     C++ Implementation of PyTorch Tutorials for Everyone
     <br />
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-1.12.0-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-1.13.1-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  1.12.0                                                |
+| OS (Compiler)\\LibTorch |                                                  1.13.1                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
 |    macOS (clang 11, 12, 13)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
 |      Linux (gcc 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
@@ -52,7 +52,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
-3. [LibTorch v1.12.0](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch version >= 1.12.0 and <= 1.13.1](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(11.3\|11.6\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.6\|11.7\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |
@@ -116,14 +116,14 @@ cmake -B build \
 <summary><b>Example Windows</b></summary>
 
 ##### Aim
-* Automatically download LibTorch for CUDA 11.6 (Release version) and all necessary datasets.
+* Automatically download LibTorch for CUDA 11.7 (Release version) and all necessary datasets.
 * Do not create scriptmodule files.
 
 ##### Command
 ```bash
 cmake -B build \
 -A x64 \
--D CUDA_V=11.6
+-D CUDA_V=11.7
 ```
 </details>
 

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,16 +2,16 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.3, 11.6 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.6, 11.7 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
-elseif(${CUDA_V} STREQUAL "11.3")
-    set(LIBTORCH_DEVICE "cu113")
 elseif(${CUDA_V} STREQUAL "11.6")
     set(LIBTORCH_DEVICE "cu116")
+elseif(${CUDA_V} STREQUAL "11.7")
+    set(LIBTORCH_DEVICE "cu117")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.3, 11.6 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.6, 11.7 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/notebooks/pytorch_cpp_colab_notebook.ipynb
+++ b/notebooks/pytorch_cpp_colab_notebook.ipynb
@@ -3,12 +3,8 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "Copy of Copy of pytorch_cpp_colab_notebook.ipynb",
       "private_outputs": true,
       "provenance": [],
-      "collapsed_sections": [
-        "VbwYTgxWvfMD"
-      ],
       "toc_visible": true
     },
     "kernelspec": {
@@ -27,7 +23,8 @@
         "\n",
         "![Pytorch Cpp](https://github.com/prabhuomkar/pytorch-cpp/raw/master/images/pytorch_cpp.png)\n",
         "\n",
-        "This notebook is intended to be used on [Google Colab](https://colab.research.google.com). It allows you\n",
+        "* **This notebook is intended to be used on [Google Colab](https://colab.research.google.com) ONLY!** \n",
+        "* It allows you\n",
         "to build and run the [pytorch-cpp](https://github.com/prabhuomkar/pytorch-cpp) tutorials on a hosted GPU equipped system for free."
       ]
     },
@@ -138,15 +135,30 @@
         "id": "cs1nFZkH59Nb"
       },
       "source": [
-        "##Install more recent CMake Version"
+        "##Install more recent versions of dependencies and build tools\n",
+        "(This takes several minutes)"
       ]
     },
     {
       "cell_type": "code",
-      "metadata": {
-        "id": "m2Lf4RSjou6t"
-      },
       "source": [
+        "# Update CUDA \n",
+        "!wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin\n",
+        "!sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600\n",
+        "!wget https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda-repo-ubuntu1804-11-6-local_11.6.0-510.39.01-1_amd64.deb\n",
+        "!sudo dpkg -i 'cuda-repo-ubuntu1804-11-6-local_11.6.0-510.39.01-1_amd64.deb'\n",
+        "!sudo apt-key add /var/cuda-repo-ubuntu1804-11-6-local/7fa2af80.pub\n",
+        "!sudo apt-get update\n",
+        "!sudo DEBIAN_FRONTEND=noninteractive apt-get -y install cuda-11-6\n",
+        "!sudo cp /usr/include/x86_64-linux-gnu/cudnn*.h /usr/local/cuda-11.6/include\n",
+        "!sudo cp /usr/lib/x86_64-linux-gnu/libcudnn* /usr/local/cuda-11.6/lib64\n",
+        "!sudo chmod a+r /usr/local/cuda-11.6/include/cudnn*.h /usr/local/cuda-11.6/lib64/libcudnn*\n",
+        "old_ld_library_path = %env LD_LIBRARY_PATH\n",
+        "new_ld_library_path = \"/usr/local/cuda-11.6/lib64:\" + old_ld_library_path\n",
+        "%env LD_LIBRARY_PATH={new_ld_library_path}\n",
+        "%env CUDA_HOME=/usr/local/cuda-11.6\n",
+        "\n",
+        "# Update CMake\n",
         "!rm -rf deps\n",
         "!mkdir deps\n",
         "%cd /content/deps\n",
@@ -157,8 +169,17 @@
         "new_path = \"/content/deps/cmake-install:/content/deps/cmake-install/bin:\" + old_path\n",
         "%env PATH={new_path}\n",
         "%cd /content/\n",
-        "!cmake --version"
+        "!cmake --version\n",
+        "\n",
+        "# Update g++\n",
+        "!sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y\n",
+        "!sudo apt-get update\n",
+        "!sudo apt-get install gcc-10 g++-10 -y\n",
+        "!sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10"
       ],
+      "metadata": {
+        "id": "yS5dYChCtqzP"
+      },
       "execution_count": null,
       "outputs": []
     },
@@ -189,8 +210,8 @@
         "echo \"\"\n",
         "pip show torchvision\n",
         "echo \"\"\n",
-        "# GPU Informations\n",
-        "nvidia-smi"
+        "# CUDA Information\n",
+        "nvcc --version"
       ],
       "execution_count": null,
       "outputs": []
@@ -232,8 +253,9 @@
         "id": "rbeD5lKStWhS"
       },
       "source": [
+        "%cd /content/pytorch-cpp\n",
         "%rm -rf build\n",
-        "!cmake -B build -D CUDA_V=11.1 -D CMAKE_BUILD_TYPE=Release"
+        "!cmake -B build -D CUDA_V=11.6 -D CMAKE_BUILD_TYPE=Release"
       ],
       "execution_count": null,
       "outputs": []
@@ -253,6 +275,7 @@
         "id": "H-n_1d4Mt8MG"
       },
       "source": [
+        "%cd /content/pytorch-cpp\n",
         "!cmake --build build"
       ],
       "execution_count": null,
@@ -273,7 +296,7 @@
         "* [Feedforward Neural Network](#scrollTo=ywmM2xkt1mi0)\n",
         "\n",
         "### 2. Intermediate\n",
-        "* [Convolutional Neural Network](#scrollTo=2gjZC6b_2PEz)\n",
+        "* [Convolutional Neural Network](#scrollTo=Convolutional_Neural_Network)\n",
         "* [Deep Residual Network](#scrollTo=Kla2SaVv228f)\n",
         "* [Recurrent Neural Network](#scrollTo=aTrOcUke3Zxu)\n",
         "* [Bidirectional Recurrent Neural Network](#scrollTo=FVVx0XFY3yvU)\n",
@@ -322,7 +345,7 @@
       },
       "source": [
         "# Create required torchscript module:\n",
-        "%cd /content/pytorch-cpp/tutorials/basics/pytorch_basics/models/\n",
+        "%cd /content/pytorch-cpp/tutorials/basics/pytorch_basics/model/\n",
         "!python create_resnet18_scriptmodule.py"
       ],
       "execution_count": null,
@@ -473,12 +496,12 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "2gjZC6b_2PEz"
-      },
       "source": [
         "###Convolutional Neural Network"
-      ]
+      ],
+      "metadata": {
+        "id": "amr2BK2XpJ5j"
+      }
     },
     {
       "cell_type": "code",

--- a/tutorials/basics/linear_regression/main.cpp
+++ b/tutorials/basics/linear_regression/main.cpp
@@ -14,8 +14,8 @@ int main() {
     const double learning_rate = 0.001;
 
     // Sample dataset
-    auto x_train = torch::randint(0, 10, {15, 1});
-    auto y_train = torch::randint(0, 10, {15, 1});
+    auto x_train = torch::randint(0, 10, {15, 1}, torch::kFloat);
+    auto y_train = torch::randint(0, 10, {15, 1}, torch::kFloat);
 
     // Linear regression model
     torch::nn::Linear model(input_size, output_size);

--- a/tutorials/basics/linear_regression/main.cpp
+++ b/tutorials/basics/linear_regression/main.cpp
@@ -5,7 +5,11 @@
 
 int main() {
     std::cout << "Linear Regression\n\n";
-    std::cout << "Training on CPU.\n";
+
+    // Device
+    auto cuda_available = torch::cuda::is_available();
+    torch::Device device(cuda_available ? torch::kCUDA : torch::kCPU);
+    std::cout << (cuda_available ? "CUDA available. Training on GPU." : "Training on CPU.") << '\n';
 
     // Hyper parameters
     const int64_t input_size = 1;
@@ -14,11 +18,15 @@ int main() {
     const double learning_rate = 0.001;
 
     // Sample dataset
-    auto x_train = torch::randint(0, 10, {15, 1}, torch::kFloat);
-    auto y_train = torch::randint(0, 10, {15, 1}, torch::kFloat);
+    auto x_train = torch::randint(0, 10, {15, 1},
+                                  torch::TensorOptions(torch::kFloat).device(device));
+
+    auto y_train = torch::randint(0, 10, {15, 1},
+                                  torch::TensorOptions(torch::kFloat).device(device));
 
     // Linear regression model
     torch::nn::Linear model(input_size, output_size);
+    model->to(device);
 
     // Optimizer
     torch::optim::SGD optimizer(model->parameters(), torch::optim::SGDOptions(learning_rate));
@@ -31,7 +39,7 @@ int main() {
     // Train the model
     for (size_t epoch = 0; epoch != num_epochs; ++epoch) {
         // Forward pass
-        auto output = model(x_train);
+        auto output = model->forward(x_train);
         auto loss = torch::nn::functional::mse_loss(output, y_train);
 
         // Backward pass and optimize


### PR DESCRIPTION
## Description of the change
* Upgrades libtorch to 1.13.1 in CMake and Docker setup.
* Updates available CUDA version  options (11.6 and 11.7) for libtorch download via CMake.
* The CMake setup now allows to use a range of libtorch versions (>= 1.12.0, <= 1.13.1) when `CMAKE_PREFIX_PATH` is used.
* Sets linear regression tutorial data dtypes explicitly to float (int-type caused a type-mismatch error with latest libtorch). Also the tutorial now uses the GPU if available - same as other tutorials.
* Updates colab notebook to work with latest libtorch versions. A more recent CUDA version (v11.6 - Colab has incompatible v11.2 by default which causes compilation errors) and more recent g++ are now installed before building the tutorials. 

## Type Of Change
- [x] New Feature

## Related Issues

Closes #105 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
