### PR TITLE
Upgrade libtorch v2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "1.13.1")
+set(PYTORCH_VERSION "2.0.0")
 set(PYTORCH_MIN_VERSION "1.12.0")
 
 find_package(Torch QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if((NOT Torch_FOUND) OR (("${Torch_VERSION}" VERSION_LESS "${PYTORCH_MIN_VERSION
 endif()
 
 message(STATUS "Torch version ${Torch_VERSION}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
 if(CREATE_SCRIPTMODULES)
     find_package(Python3 COMPONENTS Interpreter REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 message(STATUS "Torch version ${Torch_VERSION}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
+
 if(CREATE_SCRIPTMODULES)
     find_package(Python3 COMPONENTS Interpreter REQUIRED)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
 
 FROM conda AS conda-installs
 # Install pytorch for CPU and torchvision.
-ARG PYTORCH_VERSION=1.13.1
-ARG TORCHVISION_VERSION=0.14.1
+ARG PYTORCH_VERSION=2.0.0
+ARG TORCHVISION_VERSION=0.15.1
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
     C++ Implementation of PyTorch Tutorials for Everyone
     <br />
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-1.13.1-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-2.0.0-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  1.13.1                                                |
+| OS (Compiler)\\LibTorch |                                                  2.0.0                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
 |    macOS (clang 11, 12, 13)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
 |      Linux (gcc 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
@@ -52,7 +52,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
-3. [LibTorch version >= 1.12.0 and <= 1.13.1](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch version >= 1.12.0 and <= 2.0.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(11.6\|11.7\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.7\|11.8\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |
@@ -116,14 +116,14 @@ cmake -B build \
 <summary><b>Example Windows</b></summary>
 
 ##### Aim
-* Automatically download LibTorch for CUDA 11.7 (Release version) and all necessary datasets.
+* Automatically download LibTorch for CUDA 11.8 (Release version) and all necessary datasets.
 * Do not create scriptmodule files.
 
 ##### Command
 ```bash
 cmake -B build \
 -A x64 \
--D CUDA_V=11.7
+-D CUDA_V=11.8
 ```
 </details>
 

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,16 +2,16 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.6, 11.7 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.7, 11.8 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
-elseif(${CUDA_V} STREQUAL "11.6")
-    set(LIBTORCH_DEVICE "cu116")
 elseif(${CUDA_V} STREQUAL "11.7")
     set(LIBTORCH_DEVICE "cu117")
+elseif(${CUDA_V} STREQUAL "11.8")
+    set(LIBTORCH_DEVICE "cu118")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.6, 11.7 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.7, 11.8 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/notebooks/pytorch_cpp_colab_notebook.ipynb
+++ b/notebooks/pytorch_cpp_colab_notebook.ipynb
@@ -1,18 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "private_outputs": true,
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -50,9 +36,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "s7-GsT7v-TAh"
+        "id": "s7-GsT7v-TAh",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# For nicer looking images\n",
         "%matplotlib inline\n",
@@ -67,15 +58,18 @@
         "import matplotlib.pyplot as plt\n",
         "import pandas as pd\n",
         "import os"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "2ASwLgYo3AkT"
+        "id": "2ASwLgYo3AkT",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Image plotting helper function\n",
         "def plot_images(file_paths, nrows, ncols, figsize_per_image):\n",
@@ -125,9 +119,7 @@
         "    df = create_output_datafram(output_path)\n",
         "    for p, _ in zip(df.itertuples(), widgets.Grid(len(df), 1)):\n",
         "        create_tab(p)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -141,6 +133,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yS5dYChCtqzP",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "# Update CUDA \n",
         "!wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin\n",
@@ -176,12 +176,7 @@
         "!sudo apt-get update\n",
         "!sudo apt-get install gcc-10 g++-10 -y\n",
         "!sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10"
-      ],
-      "metadata": {
-        "id": "yS5dYChCtqzP"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -194,9 +189,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "pMMGmOVmra8B"
+        "id": "pMMGmOVmra8B",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%%bash\n",
         "# Preinstalled compiler versions\n",
@@ -212,9 +212,7 @@
         "echo \"\"\n",
         "# CUDA Information\n",
         "nvcc --version"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -227,16 +225,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "pYr7GTcGsnvx"
+        "id": "pYr7GTcGsnvx",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "!git clone https://github.com/prabhuomkar/pytorch-cpp.git\n",
         "%cd /content/pytorch-cpp\n",
         "%ls"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -249,16 +250,19 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "rbeD5lKStWhS"
+        "id": "rbeD5lKStWhS",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%cd /content/pytorch-cpp\n",
         "%rm -rf build\n",
-        "!cmake -B build -D CUDA_V=11.6 -D CMAKE_BUILD_TYPE=Release"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "!cmake -B build -D CUDA_V=11.8 -D CMAKE_BUILD_TYPE=Release"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -271,15 +275,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "H-n_1d4Mt8MG"
+        "id": "H-n_1d4Mt8MG",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%cd /content/pytorch-cpp\n",
         "!cmake --build build"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -320,14 +327,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "U1S-Iruk0GAB"
+        "id": "U1S-Iruk0GAB",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/basics/ -1"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -340,40 +350,49 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Ev7P19zzzRfu"
+        "id": "Ev7P19zzzRfu",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Create required torchscript module:\n",
         "%cd /content/pytorch-cpp/tutorials/basics/pytorch_basics/model/\n",
         "!python create_resnet18_scriptmodule.py"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Z2pMypzTywYj"
+        "id": "Z2pMypzTywYj",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/basics/pytorch_basics/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "l4YOWqn2y_0G"
+        "id": "l4YOWqn2y_0G",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%cd /content/pytorch-cpp/build/tutorials/basics/pytorch_basics/\n",
         "!./pytorch-basics"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -386,27 +405,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "BPXFDYqO1DqW"
+        "id": "BPXFDYqO1DqW",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/basics/linear_regression/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "6agvmvVh1J7f"
+        "id": "6agvmvVh1J7f",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%cd /content/pytorch-cpp/build/tutorials/basics/linear_regression/\n",
         "!./linear-regression"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -419,27 +444,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "mIBloL341Yis"
+        "id": "mIBloL341Yis",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/basics/logistic_regression/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qkKPAWBk1d9V"
+        "id": "qkKPAWBk1d9V",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%cd /content/pytorch-cpp/build/tutorials/basics/logistic_regression/\n",
         "!./logistic-regression"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -452,27 +483,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "jZsPU07C1p-K"
+        "id": "jZsPU07C1p-K",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/basics/feedforward_neural_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "DAgpSavJ1tjH"
+        "id": "DAgpSavJ1tjH",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%cd /content/pytorch-cpp/build/tutorials/basics/feedforward_neural_network/\n",
         "!./feedforward-neural-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -485,48 +522,57 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "TVcLYosB16Xi"
+        "id": "TVcLYosB16Xi",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/intermediate/ -1"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "###Convolutional Neural Network"
-      ],
       "metadata": {
         "id": "amr2BK2XpJ5j"
-      }
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-ERzOw4F2ap1"
       },
       "source": [
-        "%ls /content/pytorch-cpp/build/tutorials/intermediate/convolutional_neural_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+        "###Convolutional Neural Network"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "PygE27Dq2mUp"
+        "id": "-ERzOw4F2ap1",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
+      "source": [
+        "%ls /content/pytorch-cpp/build/tutorials/intermediate/convolutional_neural_network/"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PygE27Dq2mUp",
+        "vscode": {
+          "languageId": "python"
+        }
+      },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/intermediate/convolutional_neural_network/\n",
         "!./convolutional-neural-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -539,28 +585,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "grh7dIl-2y_5"
+        "id": "grh7dIl-2y_5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/intermediate/deep_residual_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "t6sxgY3U28Fj"
+        "id": "t6sxgY3U28Fj",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/intermediate/deep_residual_network/\n",
         "!./deep-residual-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -573,28 +625,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "m2C4zWx_3iyM"
+        "id": "m2C4zWx_3iyM",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/intermediate/recurrent_neural_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xqEYhxql3qKr"
+        "id": "xqEYhxql3qKr",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/intermediate/recurrent_neural_network/\n",
         "!./recurrent-neural-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -607,28 +665,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "XwKsI8Cc315L"
+        "id": "XwKsI8Cc315L",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/intermediate/bidirectional_recurrent_neural_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "GvZmNxTr34eM"
+        "id": "GvZmNxTr34eM",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/intermediate/bidirectional_recurrent_neural_network/\n",
         "!./bidirectional-recurrent-neural-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -641,40 +705,49 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "mvKxwskb4K81"
+        "id": "mvKxwskb4K81",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/intermediate/language_model/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "RcHpHp3-4OMw"
+        "id": "RcHpHp3-4OMw",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/intermediate/language_model/\n",
         "!./language-model"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "u8sZ3Wk2720U"
+        "id": "u8sZ3Wk2720U",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Results\n",
         "%cat /content/pytorch-cpp/build/tutorials/intermediate/language_model/output/sample.txt"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -687,14 +760,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xZKTaitM4e9L"
+        "id": "xZKTaitM4e9L",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/advanced/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -707,48 +783,62 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "t3ehQI_O8bEM"
+        "id": "t3ehQI_O8bEM",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/advanced/generative_adversarial_network/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "xPKI6qSw8n2F"
+        "id": "xPKI6qSw8n2F",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/advanced/generative_adversarial_network/\n",
         "!./generative-adversarial-network"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "CQ7Dt6dr9Hug"
+        "id": "CQ7Dt6dr9Hug",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Results\n",
         "%ls /content/pytorch-cpp/build/tutorials/advanced/generative_adversarial_network/output/ -1 -r --sort=time | head -10\n",
         "!echo \"...\"\n",
         "%ls /content/pytorch-cpp/build/tutorials/advanced/generative_adversarial_network/output/ -1 -r --sort=time | tail -10"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "LDZDvBUALJtw"
+        "id": "LDZDvBUALJtw",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Show results:\n",
         "# Get paths of output files sorted by creation time:\n",
@@ -758,9 +848,7 @@
         "gan_file_paths = [gan_output_file_paths[i] for i in gan_display_indices]\n",
         "\n",
         "plot_images(gan_file_paths, nrows=1, ncols=len(gan_file_paths), figsize_per_image=(5, 5))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -773,57 +861,69 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "qP1x5N6PFLw5"
+        "id": "qP1x5N6PFLw5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/advanced/variational_autoencoder/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Y2PHWLYVFXR5"
+        "id": "Y2PHWLYVFXR5",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/advanced/variational_autoencoder/\n",
         "!./variational-autoencoder"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "szHaGKCfFsju"
+        "id": "szHaGKCfFsju",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Results\n",
         "%ls /content/pytorch-cpp/build/tutorials/advanced/variational_autoencoder/output/ -1 -r --sort=time | head -10\n",
         "!echo \"...\"\n",
         "%ls /content/pytorch-cpp/build/tutorials/advanced/variational_autoencoder/output/ -1 -r --sort=time | tail -10"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "elkk38xaGJLU"
+        "id": "elkk38xaGJLU",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "vae_output_file_paths = sorted(list(Path(\"./output\").iterdir()), key=os.path.getmtime)\n",
         "vae_display_indices = [1, 0, len(vae_output_file_paths) // 2, len(vae_output_file_paths) // 2 - 1, len(vae_output_file_paths) - 1, len(vae_output_file_paths) - 2]\n",
         "vae_file_paths = [vae_output_file_paths[i] for i in vae_display_indices]\n",
         "\n",
         "plot_images(vae_file_paths, nrows=len(vae_file_paths) // 2, ncols=2, figsize_per_image=(9, 5))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -836,91 +936,112 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "IaEqJbsXZjBD"
+        "id": "IaEqJbsXZjBD",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Create required torchscript module:\n",
         "%cd /content/pytorch-cpp/tutorials/advanced/neural_style_transfer/model/\n",
         "!python create_vgg19_layers_scriptmodule.py"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "x-oKRmdZZSbz"
+        "id": "x-oKRmdZZSbz",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/advanced/neural_style_transfer/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "bPrnqcFvZXJU"
+        "id": "bPrnqcFvZXJU",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/advanced/neural_style_transfer/\n",
         "!./neural-style-transfer"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Eo8v_9s9eUvR"
+        "id": "Eo8v_9s9eUvR",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Results\n",
         "%ls /content/pytorch-cpp/build/tutorials/advanced/neural_style_transfer/output/ -1 -r --sort=time"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "7RW9fPEyfus8"
+        "id": "7RW9fPEyfus8",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Inputs\n",
         "%ls /content/pytorch-cpp/data/neural_style_transfer_images/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "vSJXkbn2hcgK"
+        "id": "vSJXkbn2hcgK",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "nst_input_file_paths = sorted(list(Path(\"/content/pytorch-cpp/data/neural_style_transfer_images\").iterdir()))\n",
         "\n",
         "plot_images(nst_input_file_paths, nrows=1, ncols=len(nst_input_file_paths), figsize_per_image=(8, 5))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Qhyn-FrkekZa"
+        "id": "Qhyn-FrkekZa",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "nst_output_file_paths = sorted(list(Path(\"/content/pytorch-cpp/build/tutorials/advanced/neural_style_transfer/output\").iterdir()), key=os.path.getmtime)\n",
         "\n",
         "plot_images(nst_output_file_paths, nrows=len(nst_output_file_paths), ncols=1, figsize_per_image=(7, 5))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -933,66 +1054,95 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "s-sgAqiJiGEC"
+        "id": "s-sgAqiJiGEC",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Create required torchscript module:\n",
         "%cd /content/pytorch-cpp/tutorials/advanced/image_captioning/model/\n",
         "!python create_encoder_cnn_backbone_scriptmodule.py"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "VltI7w1tAuJt"
+        "id": "VltI7w1tAuJt",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "%ls /content/pytorch-cpp/build/tutorials/advanced/image_captioning/"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "95UQmwSSBA4X"
+        "id": "95UQmwSSBA4X",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Show command line arguments:\n",
         "%cd /content/pytorch-cpp/build/tutorials/advanced/image_captioning/\n",
         "!./image-captioning --help"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "APa5ygazA1aw"
+        "id": "APa5ygazA1aw",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Run\n",
         "%%time\n",
         "%cd /content/pytorch-cpp/build/tutorials/advanced/image_captioning/\n",
         "!./image-captioning --batch_size=128 --num_epochs=4"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "Do8Q7qzxBINd"
+        "id": "Do8Q7qzxBINd",
+        "vscode": {
+          "languageId": "python"
+        }
       },
+      "outputs": [],
       "source": [
         "# Results\n",
         "plot_image_caption_output(Path(\"/content/pytorch-cpp/build/tutorials/advanced/image_captioning/output\"))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "private_outputs": true,
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
## Description of the change

* Upgrades libtorch to 2.0.0 in CMake and Docker setup.
* Updates available CUDA version options (11.7 and 11.8) for libtorch download via CMake.
* Adds `TORCH_CXX_FLAGS` as in official documentation.
* Explicitly adds `-pthread` to `CMAKE_CXX_FLAGS` on Linux, as without it, errors occur (missing reference to `pthread_create`) when compiling on Ubuntu 20.04 (at least in CI).
* No tutorial code changes.

## Type Of Change
- [x] New Feature

## Related Issues
Closes #107 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
