### PR TITLE
Update git URL for stb

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -21,7 +21,7 @@ FetchContent_MakeAvailable(extern_cxxopts)
 foreach(STB_IMAGE_LIB "stb_image" "stb_image_write" "stb_image_resize")
     FetchContent_Declare(
         extern_${STB_IMAGE_LIB}
-        URL https://raw.githubusercontent.com/nothings/stb/master/${STB_IMAGE_LIB}.h
+        URL https://raw.githubusercontent.com/nothings/obbg/master/stb/${STB_IMAGE_LIB}.h
         DOWNLOAD_NO_EXTRACT ON  
         DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${STB_IMAGE_LIB}
     )


### PR DESCRIPTION
## Description of the change

stb library link needs to be updated as the old URL is nonexistent for stb_image_resize.h
