### PR TITLE
Upgrade libtorch v2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "2.0.0")
+set(PYTORCH_VERSION "2.1.1")
 set(PYTORCH_MIN_VERSION "1.12.0")
 
 find_package(Torch QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
 
 FROM conda AS conda-installs
 # Install pytorch for CPU and torchvision.
-ARG PYTORCH_VERSION=2.0.0
-ARG TORCHVISION_VERSION=0.15.1
+ARG PYTORCH_VERSION=2.1.1
+ARG TORCHVISION_VERSION=0.16.1
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
     C++ Implementation of PyTorch Tutorials for Everyone
     <br />
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-2.0.0-ee4c2c">
+<img src="https://img.shields.io/badge/libtorch-2.1.1-ee4c2c">
 <img src="https://img.shields.io/badge/cmake-3.14-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  2.0.0                                                |
+| OS (Compiler)\\LibTorch |                                                  2.1.1                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
 |    macOS (clang 11, 12, 13)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
 |      Linux (gcc 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
@@ -52,7 +52,7 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 
 1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
 2. [CMake](https://cmake.org/download/) (minimum version 3.14)
-3. [LibTorch version >= 1.12.0 and <= 2.0.0](https://pytorch.org/cppdocs/installing.html)
+3. [LibTorch version >= 1.12.0 and <= 2.1.1](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(11.7\|11.8\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.8\|12.1\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,16 +2,16 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.7, 11.8 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.8, 12.1 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
-elseif(${CUDA_V} STREQUAL "11.7")
-    set(LIBTORCH_DEVICE "cu117")
 elseif(${CUDA_V} STREQUAL "11.8")
     set(LIBTORCH_DEVICE "cu118")
+elseif(${CUDA_V} STREQUAL "12.1")
+    set(LIBTORCH_DEVICE "cu121")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.7, 11.8 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.8, 12.1 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/utils/image_io/CMakeLists.txt
+++ b/utils/image_io/CMakeLists.txt
@@ -16,6 +16,6 @@ target_include_directories(image-io PUBLIC include)
 target_link_libraries(image-io ${TORCH_LIBRARIES} stb-image stb-image-write stb-image-resize2)
                           
 set_target_properties(image-io PROPERTIES
-  CXX_STANDARD 14
+  CXX_STANDARD 17
   CXX_STANDARD_REQUIRED YES
 )


### PR DESCRIPTION
## Description of the change

* Upgrades libtorch to 2.1.1 in CMake and Docker setup.
* Updates available CUDA version options (11.8 and 12.1) for libtorch download via CMake.
* Updates `image-io` utility library's CXX standard to 17 as integration with libtorch now requires C++17.
* No tutorial code changes.

## Type Of Change
- [x] New Feature

## Related Issues
Closes #119 .

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers