### PR TITLE
Housekeeping and PyTorch Upgrade

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -18,18 +18,18 @@ on:
 
 jobs:
   build-mac:
-    name: "macOS 14.4.1 arm64 Xcode (Clang)"
+    name: "macOS 14 arm64 Xcode (Clang)"
     runs-on: macos-14
     strategy:
       matrix:
-        xcode: [14.3.1, 15.3]
+        xcode: [15.3, 16.1]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.19.0'
+        cmake-version: '3.28.6'
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -18,18 +18,18 @@ on:
 
 jobs:
   build-ubuntu:
-    name: "Ubuntu 22.04 GCC"
-    runs-on: ubuntu-22.04
+    name: "Ubuntu 24.04 GCC"
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        gcc: [11, 12, 13]
+        gcc: [13, 14]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: '3.19.0'
+        cmake-version: '3.28.6'
     - name: Set up GCC
       uses: egor-tensin/setup-gcc@v1
       with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -24,14 +24,14 @@ jobs:
       matrix:
         config:
         - {
-            name: Windows MSVC 2019,
-            os: windows-2019,
-            cmake: '3.19.0'
-          }
-        - {
             name: Windows MSVC 2022,
             os: windows-2022,
-            cmake: '3.24.2'
+            cmake: '3.28.6'
+          }
+        - {
+            name: Windows MSVC 2025,
+            os: windows-2025,
+            cmake: '3.28.6'
           }
     steps:
     - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(pytorch-cpp VERSION 1.0.0 LANGUAGES CXX)
 
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(DOWNLOAD_DATASETS "Automatically download required datasets at build-time." ON)
 option(CREATE_SCRIPTMODULES "Automatically create all required scriptmodule files at build-time (requires python3)." OFF)
 
-set(PYTORCH_VERSION "2.3.0")
+set(PYTORCH_VERSION "2.6.0")
 set(PYTORCH_MIN_VERSION "1.12.0")
 
 find_package(Torch QUIET PATHS "${CMAKE_SOURCE_DIR}/libtorch")

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl --silent --show-error --location --output ~/miniconda.sh https://repo.a
 
 FROM conda AS conda-installs
 # Install pytorch for CPU and torchvision.
-ARG PYTORCH_VERSION=2.3.0
+ARG PYTORCH_VERSION=2.6.0
 ARG TORCHVISION_VERSION=0.18.0
 ENV NO_CUDA=1
 RUN conda install pytorch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} cpuonly -y -c pytorch && conda clean -ya

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
     C++ Implementation of PyTorch Tutorials for Everyone
     <br />
 <img src="https://img.shields.io/github/license/prabhuomkar/pytorch-cpp">
-<img src="https://img.shields.io/badge/libtorch-2.3.0-ee4c2c">
-<img src="https://img.shields.io/badge/cmake-3.19-064f8d">
+<img src="https://img.shields.io/badge/libtorch-2.6.0-ee4c2c">
+<img src="https://img.shields.io/badge/cmake-3.28.6-064f8d">
 </p>
 
 
-| OS (Compiler)\\LibTorch |                                                  2.3.0                                                |
+| OS (Compiler)\\LibTorch |                                                  2.6.0                                                |
 | :--------------------- | :--------------------------------------------------------------------------------------------------- |
-|    macOS (clang 11, 12, 13)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
-|      Linux (gcc 9, 10, 11)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
-|    Windows (msvc 2019, 2022)  | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_windows.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-windows) |
+|    macOS (clang 15, 16)    | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_macos.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-macos) |
+|      Linux (gcc 13, 14)      | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_ubuntu.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-ubuntu) |
+|    Windows (msvc 2022, 2025)  | [![Status](https://github.com/prabhuomkar/pytorch-cpp/actions/workflows/build_windows.yml/badge.svg?branch=master)](https://github.com/prabhuomkar/pytorch-cpp/actions?query=workflow%3Aci-build-windows) |
 
 ## Table of Contents
 
@@ -51,8 +51,8 @@ This repository provides tutorial code in C++ for deep learning researchers to l
 ## Requirements
 
 1. [C++-17](http://www.cplusplus.com/doc/tutorial/introduction/) compatible compiler
-2. [CMake](https://cmake.org/download/) (minimum version 3.19)
-3. [LibTorch version >= 1.12.0 and <= 2.3.0](https://pytorch.org/cppdocs/installing.html)
+2. [CMake](https://cmake.org/download/) (minimum version 3.28.6)
+3. [LibTorch version >= 1.12.0 and <= 2.6.0](https://pytorch.org/cppdocs/installing.html)
 4. [Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html)
 
 
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(11.8\|12.1\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.8\|12.1\|12.6\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Some useful options:
 
 | Option       | Default           | Description  |
 | :------------- |:------------|-----:|
-| `-D CUDA_V=(11.8\|12.1\|12.6\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
+| `-D CUDA_V=(11.8\|12.4\|12.6\|none)`     | `none` | Download LibTorch for a CUDA version (`none` = download CPU version). |
 | `-D LIBTORCH_DOWNLOAD_BUILD_TYPE=(Release\|Debug)` | `Release` | Determines which libtorch build type version to download (only relevant on **Windows**).|
 | `-D DOWNLOAD_DATASETS=(OFF\|ON)`     | `ON`      |   Download required datasets during build (only if they do not already exist in `pytorch-cpp/data`). |
 |`-D CREATE_SCRIPTMODULES=(OFF\|ON)` | `OFF` | Create all required scriptmodule files for prelearned models / weights during build. Requires installed  python3 with  pytorch and torchvision. |

--- a/cmake/check_files.cmake
+++ b/cmake/check_files.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(check_files BASE_DIR FILES_TO_CHECK FILE_MD5S MISSING_FILES)
     foreach(FILE_TO_CHECK ${${FILES_TO_CHECK}})

--- a/cmake/copy_torch_dlls.cmake
+++ b/cmake/copy_torch_dlls.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(copy_torch_dlls TARGET_NAME)
     # According to https://github.com/pytorch/pytorch/issues/25457

--- a/cmake/cpplint.cmake
+++ b/cmake/cpplint.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 find_program(CPPLINT cpplint)
 

--- a/cmake/create_torch_dll_hardlinks.cmake
+++ b/cmake/create_torch_dll_hardlinks.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 file(GLOB TORCH_DLLS "${TORCH_INSTALL_PREFIX}/lib/*.dll")
                        

--- a/cmake/fetch_cifar10.cmake
+++ b/cmake/fetch_cifar10.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_cifar10 DATA_DIR)
     set(CIFAR_DIR "${DATA_DIR}/cifar10")

--- a/cmake/fetch_datasets.cmake
+++ b/cmake/fetch_datasets.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 include(${CMAKE_CURRENT_LIST_DIR}/fetch_mnist.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/fetch_cifar10.cmake)

--- a/cmake/fetch_flickr8k.cmake
+++ b/cmake/fetch_flickr8k.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_flickr8k DATA_DIR)
     set(FLICKR8K_DIR "${DATA_DIR}/flickr_8k")

--- a/cmake/fetch_imagenette.cmake
+++ b/cmake/fetch_imagenette.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_imagenette DATA_DIR)
     set(IMAGENETTE_DIR "${DATA_DIR}/imagenette2-160")

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -2,18 +2,18 @@ cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.8, 12.1, 12.6 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.8, 12.4, 12.6 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
 elseif(${CUDA_V} STREQUAL "11.8")
     set(LIBTORCH_DEVICE "cu118")
-elseif(${CUDA_V} STREQUAL "12.1")
-    set(LIBTORCH_DEVICE "cu121")
+elseif(${CUDA_V} STREQUAL "12.4")
+    set(LIBTORCH_DEVICE "cu124")
 elseif(${CUDA_V} STREQUAL "12.6")
     set(LIBTORCH_DEVICE "cu126")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.8, 12.1, 12.6 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.8, 12.4, 12.6 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/cmake/fetch_libtorch.cmake
+++ b/cmake/fetch_libtorch.cmake
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 include(FetchContent)
 
-set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.8, 12.1 or none).")
+set(CUDA_V "none" CACHE STRING "Determines libtorch CUDA version to download (11.8, 12.1, 12.6 or none).")
 
 if(${CUDA_V} STREQUAL "none")
     set(LIBTORCH_DEVICE "cpu")
@@ -10,8 +10,10 @@ elseif(${CUDA_V} STREQUAL "11.8")
     set(LIBTORCH_DEVICE "cu118")
 elseif(${CUDA_V} STREQUAL "12.1")
     set(LIBTORCH_DEVICE "cu121")
+elseif(${CUDA_V} STREQUAL "12.6")
+    set(LIBTORCH_DEVICE "cu126")
 else() 
-    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.8, 12.1 or none!")
+    message(FATAL_ERROR "Invalid CUDA version specified, must be 11.8, 12.1, 12.6 or none!")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")

--- a/cmake/fetch_mnist.cmake
+++ b/cmake/fetch_mnist.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_mnist DATA_DIR)
     set(MNIST_DOWNLOAD_DIR "${DATA_DIR}/mnist/download")

--- a/cmake/fetch_neural_style_transfer_images.cmake
+++ b/cmake/fetch_neural_style_transfer_images.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_neural_style_transfer_imagers DATA_DIR)
     set(NEURAL_STYLE_TRANSFER_IMAGES_DIR

--- a/cmake/fetch_penntreebank.cmake
+++ b/cmake/fetch_penntreebank.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 function(fetch_penntreebank DATA_DIR)
     set(PENNTREEBANK_DIR "${DATA_DIR}/penntreebank")

--- a/cmake/find_gz_extractor.cmake
+++ b/cmake/find_gz_extractor.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 # Find program that can extract .gz files.
 # Based on: https://github.com/Amber-MD/cmake-buildscripts/blob/master/gzip.cmake

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(extern VERSION 1.0.0 LANGUAGES CXX)
 

--- a/notebooks/pytorch_cpp_colab_notebook.ipynb
+++ b/notebooks/pytorch_cpp_colab_notebook.ipynb
@@ -38,10 +38,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "s7-GsT7v-TAh",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "s7-GsT7v-TAh"
       },
       "outputs": [],
       "source": [
@@ -64,10 +61,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "2ASwLgYo3AkT",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "2ASwLgYo3AkT"
       },
       "outputs": [],
       "source": [
@@ -135,10 +129,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "yS5dYChCtqzP",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "yS5dYChCtqzP"
       },
       "outputs": [],
       "source": [
@@ -162,9 +153,9 @@
         "!rm -rf deps\n",
         "!mkdir deps\n",
         "%cd /content/deps\n",
-        "!wget --no-check-certificate https://www.cmake.org/files/v3.19/cmake-3.19.0-Linux-x86_64.tar.gz\n",
-        "!tar -xvf cmake-3.19.0-Linux-x86_64.tar.gz > /dev/null\n",
-        "%mv cmake-3.19.0-Linux-x86_64 cmake-install\n",
+        "!wget --no-check-certificate https://www.cmake.org/files/v3.28/cmake-3.28.6-linux-x86_64.tar.gz\n",
+        "!tar -xvf cmake-3.28.6-linux-x86_64.tar.gz > /dev/null\n",
+        "%mv cmake-3.28.6-linux-x86_64 cmake-install\n",
         "old_path = %env PATH\n",
         "new_path = \"/content/deps/cmake-install:/content/deps/cmake-install/bin:\" + old_path\n",
         "%env PATH={new_path}\n",
@@ -191,10 +182,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "pMMGmOVmra8B",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "pMMGmOVmra8B"
       },
       "outputs": [],
       "source": [
@@ -227,10 +215,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "pYr7GTcGsnvx",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "pYr7GTcGsnvx"
       },
       "outputs": [],
       "source": [
@@ -252,10 +237,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "rbeD5lKStWhS",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "rbeD5lKStWhS"
       },
       "outputs": [],
       "source": [
@@ -277,10 +259,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "H-n_1d4Mt8MG",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "H-n_1d4Mt8MG"
       },
       "outputs": [],
       "source": [
@@ -329,10 +308,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "U1S-Iruk0GAB",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "U1S-Iruk0GAB"
       },
       "outputs": [],
       "source": [
@@ -352,10 +328,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Ev7P19zzzRfu",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Ev7P19zzzRfu"
       },
       "outputs": [],
       "source": [
@@ -368,10 +341,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Z2pMypzTywYj",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Z2pMypzTywYj"
       },
       "outputs": [],
       "source": [
@@ -382,10 +352,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "l4YOWqn2y_0G",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "l4YOWqn2y_0G"
       },
       "outputs": [],
       "source": [
@@ -407,10 +374,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "BPXFDYqO1DqW",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "BPXFDYqO1DqW"
       },
       "outputs": [],
       "source": [
@@ -421,10 +385,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "6agvmvVh1J7f",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "6agvmvVh1J7f"
       },
       "outputs": [],
       "source": [
@@ -446,10 +407,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "mIBloL341Yis",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "mIBloL341Yis"
       },
       "outputs": [],
       "source": [
@@ -460,10 +418,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "qkKPAWBk1d9V",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "qkKPAWBk1d9V"
       },
       "outputs": [],
       "source": [
@@ -485,10 +440,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "jZsPU07C1p-K",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "jZsPU07C1p-K"
       },
       "outputs": [],
       "source": [
@@ -499,10 +451,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "DAgpSavJ1tjH",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "DAgpSavJ1tjH"
       },
       "outputs": [],
       "source": [
@@ -524,10 +473,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "TVcLYosB16Xi",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "TVcLYosB16Xi"
       },
       "outputs": [],
       "source": [
@@ -547,10 +493,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "-ERzOw4F2ap1",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "-ERzOw4F2ap1"
       },
       "outputs": [],
       "source": [
@@ -561,10 +504,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "PygE27Dq2mUp",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "PygE27Dq2mUp"
       },
       "outputs": [],
       "source": [
@@ -587,10 +527,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "grh7dIl-2y_5",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "grh7dIl-2y_5"
       },
       "outputs": [],
       "source": [
@@ -601,10 +538,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "t6sxgY3U28Fj",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "t6sxgY3U28Fj"
       },
       "outputs": [],
       "source": [
@@ -627,10 +561,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "m2C4zWx_3iyM",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "m2C4zWx_3iyM"
       },
       "outputs": [],
       "source": [
@@ -641,10 +572,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "xqEYhxql3qKr",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "xqEYhxql3qKr"
       },
       "outputs": [],
       "source": [
@@ -667,10 +595,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "XwKsI8Cc315L",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "XwKsI8Cc315L"
       },
       "outputs": [],
       "source": [
@@ -681,10 +606,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "GvZmNxTr34eM",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "GvZmNxTr34eM"
       },
       "outputs": [],
       "source": [
@@ -707,10 +629,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "mvKxwskb4K81",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "mvKxwskb4K81"
       },
       "outputs": [],
       "source": [
@@ -721,10 +640,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "RcHpHp3-4OMw",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "RcHpHp3-4OMw"
       },
       "outputs": [],
       "source": [
@@ -738,10 +654,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "u8sZ3Wk2720U",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "u8sZ3Wk2720U"
       },
       "outputs": [],
       "source": [
@@ -762,10 +675,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "xZKTaitM4e9L",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "xZKTaitM4e9L"
       },
       "outputs": [],
       "source": [
@@ -785,10 +695,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "t3ehQI_O8bEM",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "t3ehQI_O8bEM"
       },
       "outputs": [],
       "source": [
@@ -799,10 +706,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "xPKI6qSw8n2F",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "xPKI6qSw8n2F"
       },
       "outputs": [],
       "source": [
@@ -816,10 +720,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "CQ7Dt6dr9Hug",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "CQ7Dt6dr9Hug"
       },
       "outputs": [],
       "source": [
@@ -833,10 +734,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "LDZDvBUALJtw",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "LDZDvBUALJtw"
       },
       "outputs": [],
       "source": [
@@ -863,10 +761,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "qP1x5N6PFLw5",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "qP1x5N6PFLw5"
       },
       "outputs": [],
       "source": [
@@ -877,10 +772,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Y2PHWLYVFXR5",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Y2PHWLYVFXR5"
       },
       "outputs": [],
       "source": [
@@ -894,10 +786,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "szHaGKCfFsju",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "szHaGKCfFsju"
       },
       "outputs": [],
       "source": [
@@ -911,10 +800,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "elkk38xaGJLU",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "elkk38xaGJLU"
       },
       "outputs": [],
       "source": [
@@ -938,10 +824,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "IaEqJbsXZjBD",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "IaEqJbsXZjBD"
       },
       "outputs": [],
       "source": [
@@ -954,10 +837,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "x-oKRmdZZSbz",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "x-oKRmdZZSbz"
       },
       "outputs": [],
       "source": [
@@ -968,10 +848,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "bPrnqcFvZXJU",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "bPrnqcFvZXJU"
       },
       "outputs": [],
       "source": [
@@ -985,10 +862,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Eo8v_9s9eUvR",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Eo8v_9s9eUvR"
       },
       "outputs": [],
       "source": [
@@ -1000,10 +874,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "7RW9fPEyfus8",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "7RW9fPEyfus8"
       },
       "outputs": [],
       "source": [
@@ -1015,10 +886,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "vSJXkbn2hcgK",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "vSJXkbn2hcgK"
       },
       "outputs": [],
       "source": [
@@ -1031,10 +899,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Qhyn-FrkekZa",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Qhyn-FrkekZa"
       },
       "outputs": [],
       "source": [
@@ -1056,10 +921,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "s-sgAqiJiGEC",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "s-sgAqiJiGEC"
       },
       "outputs": [],
       "source": [
@@ -1072,10 +934,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "VltI7w1tAuJt",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "VltI7w1tAuJt"
       },
       "outputs": [],
       "source": [
@@ -1086,10 +945,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "95UQmwSSBA4X",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "95UQmwSSBA4X"
       },
       "outputs": [],
       "source": [
@@ -1102,10 +958,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "APa5ygazA1aw",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "APa5ygazA1aw"
       },
       "outputs": [],
       "source": [
@@ -1119,10 +972,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "Do8Q7qzxBINd",
-        "vscode": {
-          "languageId": "python"
-        }
+        "id": "Do8Q7qzxBINd"
       },
       "outputs": [],
       "source": [

--- a/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
+++ b/tutorials/advanced/generative_adversarial_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(generative-adversarial-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/advanced/image_captioning/CMakeLists.txt
+++ b/tutorials/advanced/image_captioning/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(image-captioning VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/advanced/neural_style_transfer/CMakeLists.txt
+++ b/tutorials/advanced/neural_style_transfer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(neural-style-transfer VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/advanced/variational_autoencoder/CMakeLists.txt
+++ b/tutorials/advanced/variational_autoencoder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(variational-autoencoder VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/basics/feedforward_neural_network/CMakeLists.txt
+++ b/tutorials/basics/feedforward_neural_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(feedforward-neural-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/basics/linear_regression/CMakeLists.txt
+++ b/tutorials/basics/linear_regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(linear-regression VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/basics/logistic_regression/CMakeLists.txt
+++ b/tutorials/basics/logistic_regression/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(logistic-regression VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/basics/pytorch_basics/CMakeLists.txt
+++ b/tutorials/basics/pytorch_basics/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(pytorch-basics VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/intermediate/bidirectional_recurrent_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/bidirectional_recurrent_neural_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(bidirectional-recurrent-neural-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/intermediate/convolutional_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/convolutional_neural_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(convolutional-neural-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/intermediate/deep_residual_network/CMakeLists.txt
+++ b/tutorials/intermediate/deep_residual_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(deep-residual-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/intermediate/language_model/CMakeLists.txt
+++ b/tutorials/intermediate/language_model/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(language-model VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/intermediate/recurrent_neural_network/CMakeLists.txt
+++ b/tutorials/intermediate/recurrent_neural_network/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(recurrent-neural-network VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/popular/blitz/autograd/CMakeLists.txt
+++ b/tutorials/popular/blitz/autograd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(autograd VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/popular/blitz/neural_networks/CMakeLists.txt
+++ b/tutorials/popular/blitz/neural_networks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(neural-networks VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/popular/blitz/tensors/CMakeLists.txt
+++ b/tutorials/popular/blitz/tensors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(tensors VERSION 1.0.0 LANGUAGES CXX)
 

--- a/tutorials/popular/blitz/training_a_classifier/CMakeLists.txt
+++ b/tutorials/popular/blitz/training_a_classifier/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(training-a-classifier VERSION 1.0.0 LANGUAGES CXX)
 

--- a/utils/image_io/CMakeLists.txt
+++ b/utils/image_io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.6 FATAL_ERROR)
 
 project(image-io VERSION 1.0.0 LANGUAGES CXX)
 


### PR DESCRIPTION
## Description of the change

- Upgrade PyTorch version to `2.6.0`
- Add CUDA `12.4` and `12.6` Support which comes with PT `2.6.0`
- Update GA Workflows for testing with latest versions
- README Updates
- Bump up CMake to `3.28.6`

## Type Of Change
- [ ] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature
- [ ] New PyTorch tutorial
- [x] Breaking Change (cmake changes, fix or feature that would cause existing functionality to not work as expected)

## Related Issues

N/A

## Development & Code Review 

- [x] cpplint rules passes locally (run `cmake -P cpplint.cmake`)
- [x] CI is passing
- [x] Changes have been reviewed by at least one of the maintainers
